### PR TITLE
Superperms compliant plugin.yml. Fixes CITIZENS-705.

### DIFF
--- a/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -212,7 +212,7 @@ public class NPCCommands {
             flags = "myn")
     public void controllable(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
         if ((npc.isSpawned() && !sender.hasPermission("citizens.npc.controllable."
-                + npc.getBukkitEntity().getType().toString().toLowerCase()))
+                + npc.getBukkitEntity().getType().name().toLowerCase().replace("_", "")))
                 || !sender.hasPermission("citizens.npc.controllable"))
             throw new NoPermissionsException();
         if (!npc.hasTrait(Controllable.class)) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,79 +27,1302 @@ commands:
     aliases: [waypoints, wp]
     description: Waypoint commands
 permissions:
+# -------------------------------------------- #
+# THE REAL NODES
+# -------------------------------------------- #
+  citizens.admin: {default: false}
+  citizens.admin.avoid-limits: {default: false}
+  citizens.admin.remove.all: {default: false}
+  citizens.citizens.help: {default: false}
+  citizens.help: {default: false}
+  citizens.npc.age: {default: false}
+  citizens.npc.anchor: {default: false}
+  citizens.npc.behaviour: {default: false}
+  citizens.npc.controllable: {default: false}
+  citizens.npc.controllable.arrow: {default: false}
+  citizens.npc.controllable.bat: {default: false}
+  citizens.npc.controllable.blaze: {default: false}
+  citizens.npc.controllable.boat: {default: false}
+  citizens.npc.controllable.cavespider: {default: false}
+  citizens.npc.controllable.chicken: {default: false}
+  citizens.npc.controllable.complexpart: {default: false}
+  citizens.npc.controllable.cow: {default: false}
+  citizens.npc.controllable.creeper: {default: false}
+  citizens.npc.controllable.droppeditem: {default: false}
+  citizens.npc.controllable.egg: {default: false}
+  citizens.npc.controllable.endercrystal: {default: false}
+  citizens.npc.controllable.enderdragon: {default: false}
+  citizens.npc.controllable.enderman: {default: false}
+  citizens.npc.controllable.enderpearl: {default: false}
+  citizens.npc.controllable.endersignal: {default: false}
+  citizens.npc.controllable.experienceorb: {default: false}
+  citizens.npc.controllable.fallingblock: {default: false}
+  citizens.npc.controllable.fireball: {default: false}
+  citizens.npc.controllable.firework: {default: false}
+  citizens.npc.controllable.fishinghook: {default: false}
+  citizens.npc.controllable.ghast: {default: false}
+  citizens.npc.controllable.giant: {default: false}
+  citizens.npc.controllable.horse: {default: false}
+  citizens.npc.controllable.irongolem: {default: false}
+  citizens.npc.controllable.itemframe: {default: false}
+  citizens.npc.controllable.leashhitch: {default: false}
+  citizens.npc.controllable.lightning: {default: false}
+  citizens.npc.controllable.magmacube: {default: false}
+  citizens.npc.controllable.minecart: {default: false}
+  citizens.npc.controllable.minecartchest: {default: false}
+  citizens.npc.controllable.minecartfurnace: {default: false}
+  citizens.npc.controllable.minecarthopper: {default: false}
+  citizens.npc.controllable.minecartmobspawner: {default: false}
+  citizens.npc.controllable.minecarttnt: {default: false}
+  citizens.npc.controllable.mushroomcow: {default: false}
+  citizens.npc.controllable.ocelot: {default: false}
+  citizens.npc.controllable.painting: {default: false}
+  citizens.npc.controllable.pig: {default: false}
+  citizens.npc.controllable.pigzombie: {default: false}
+  citizens.npc.controllable.player: {default: false}
+  citizens.npc.controllable.primedtnt: {default: false}
+  citizens.npc.controllable.sheep: {default: false}
+  citizens.npc.controllable.silverfish: {default: false}
+  citizens.npc.controllable.skeleton: {default: false}
+  citizens.npc.controllable.slime: {default: false}
+  citizens.npc.controllable.smallfireball: {default: false}
+  citizens.npc.controllable.snowball: {default: false}
+  citizens.npc.controllable.snowman: {default: false}
+  citizens.npc.controllable.spider: {default: false}
+  citizens.npc.controllable.splashpotion: {default: false}
+  citizens.npc.controllable.squid: {default: false}
+  citizens.npc.controllable.thrownexpbottle: {default: false}
+  citizens.npc.controllable.villager: {default: false}
+  citizens.npc.controllable.weather: {default: false}
+  citizens.npc.controllable.witch: {default: false}
+  citizens.npc.controllable.wither: {default: false}
+  citizens.npc.controllable.witherskull: {default: false}
+  citizens.npc.controllable.wolf: {default: false}
+  citizens.npc.controllable.zombie: {default: false}
+  citizens.npc.copy: {default: false}
+  citizens.npc.create: {default: false}
+  citizens.npc.create.arrow: {default: false}
+  citizens.npc.create.bat: {default: false}
+  citizens.npc.create.blaze: {default: false}
+  citizens.npc.create.boat: {default: false}
+  citizens.npc.create.cavespider: {default: false}
+  citizens.npc.create.chicken: {default: false}
+  citizens.npc.create.complexpart: {default: false}
+  citizens.npc.create.cow: {default: false}
+  citizens.npc.create.creeper: {default: false}
+  citizens.npc.create.droppeditem: {default: false}
+  citizens.npc.create.egg: {default: false}
+  citizens.npc.create.endercrystal: {default: false}
+  citizens.npc.create.enderdragon: {default: false}
+  citizens.npc.create.enderman: {default: false}
+  citizens.npc.create.enderpearl: {default: false}
+  citizens.npc.create.endersignal: {default: false}
+  citizens.npc.create.experienceorb: {default: false}
+  citizens.npc.create.fallingblock: {default: false}
+  citizens.npc.create.fireball: {default: false}
+  citizens.npc.create.firework: {default: false}
+  citizens.npc.create.fishinghook: {default: false}
+  citizens.npc.create.ghast: {default: false}
+  citizens.npc.create.giant: {default: false}
+  citizens.npc.create.horse: {default: false}
+  citizens.npc.create.irongolem: {default: false}
+  citizens.npc.create.itemframe: {default: false}
+  citizens.npc.create.leashhitch: {default: false}
+  citizens.npc.create.lightning: {default: false}
+  citizens.npc.create.magmacube: {default: false}
+  citizens.npc.create.minecart: {default: false}
+  citizens.npc.create.minecartchest: {default: false}
+  citizens.npc.create.minecartfurnace: {default: false}
+  citizens.npc.create.minecarthopper: {default: false}
+  citizens.npc.create.minecartmobspawner: {default: false}
+  citizens.npc.create.minecarttnt: {default: false}
+  citizens.npc.create.mushroomcow: {default: false}
+  citizens.npc.create.ocelot: {default: false}
+  citizens.npc.create.painting: {default: false}
+  citizens.npc.create.pig: {default: false}
+  citizens.npc.create.pigzombie: {default: false}
+  citizens.npc.create.player: {default: false}
+  citizens.npc.create.primedtnt: {default: false}
+  citizens.npc.create.sheep: {default: false}
+  citizens.npc.create.silverfish: {default: false}
+  citizens.npc.create.skeleton: {default: false}
+  citizens.npc.create.slime: {default: false}
+  citizens.npc.create.smallfireball: {default: false}
+  citizens.npc.create.snowball: {default: false}
+  citizens.npc.create.snowman: {default: false}
+  citizens.npc.create.spider: {default: false}
+  citizens.npc.create.splashpotion: {default: false}
+  citizens.npc.create.squid: {default: false}
+  citizens.npc.create.thrownexpbottle: {default: false}
+  citizens.npc.create.villager: {default: false}
+  citizens.npc.create.weather: {default: false}
+  citizens.npc.create.witch: {default: false}
+  citizens.npc.create.wither: {default: false}
+  citizens.npc.create.witherskull: {default: false}
+  citizens.npc.create.wolf: {default: false}
+  citizens.npc.create.zombie: {default: false}
+  citizens.npc.despawn: {default: false}
+  citizens.npc.edit.copier: {default: false}
+  citizens.npc.edit.equip: {default: false}
+  citizens.npc.edit.path: {default: false}
+  citizens.npc.edit.text: {default: false}
+  citizens.npc.gravity: {default: false}
+  citizens.npc.help: {default: false}
+  citizens.npc.help: {default: false}
+  citizens.npc.horse: {default: false}
+  citizens.npc.ignore-cost: {default: false}
+  citizens.npc.info: {default: false}
+  citizens.npc.leashable: {default: false}
+  citizens.npc.limit.1: {default: false}
+  citizens.npc.limit.2: {default: false}
+  citizens.npc.limit.3: {default: false}
+  citizens.npc.limit.4: {default: false}
+  citizens.npc.limit.5: {default: false}
+  citizens.npc.limit.6: {default: false}
+  citizens.npc.limit.7: {default: false}
+  citizens.npc.limit.8: {default: false}
+  citizens.npc.limit.9: {default: false}
+  citizens.npc.limit.10: {default: false}
+  citizens.npc.limit.11: {default: false}
+  citizens.npc.limit.12: {default: false}
+  citizens.npc.limit.13: {default: false}
+  citizens.npc.limit.14: {default: false}
+  citizens.npc.limit.15: {default: false}
+  citizens.npc.limit.16: {default: false}
+  citizens.npc.limit.17: {default: false}
+  citizens.npc.limit.18: {default: false}
+  citizens.npc.limit.19: {default: false}
+  citizens.npc.limit.20: {default: false}
+  citizens.npc.limit.21: {default: false}
+  citizens.npc.limit.22: {default: false}
+  citizens.npc.limit.23: {default: false}
+  citizens.npc.limit.24: {default: false}
+  citizens.npc.limit.25: {default: false}
+  citizens.npc.limit.26: {default: false}
+  citizens.npc.limit.27: {default: false}
+  citizens.npc.limit.28: {default: false}
+  citizens.npc.limit.29: {default: false}
+  citizens.npc.limit.30: {default: false}
+  citizens.npc.limit.31: {default: false}
+  citizens.npc.limit.32: {default: false}
+  citizens.npc.limit.33: {default: false}
+  citizens.npc.limit.34: {default: false}
+  citizens.npc.limit.35: {default: false}
+  citizens.npc.limit.36: {default: false}
+  citizens.npc.limit.37: {default: false}
+  citizens.npc.limit.38: {default: false}
+  citizens.npc.limit.39: {default: false}
+  citizens.npc.limit.40: {default: false}
+  citizens.npc.limit.41: {default: false}
+  citizens.npc.limit.42: {default: false}
+  citizens.npc.limit.43: {default: false}
+  citizens.npc.limit.44: {default: false}
+  citizens.npc.limit.45: {default: false}
+  citizens.npc.limit.46: {default: false}
+  citizens.npc.limit.47: {default: false}
+  citizens.npc.limit.48: {default: false}
+  citizens.npc.limit.49: {default: false}
+  citizens.npc.limit.50: {default: false}
+  citizens.npc.limit.51: {default: false}
+  citizens.npc.limit.52: {default: false}
+  citizens.npc.limit.53: {default: false}
+  citizens.npc.limit.54: {default: false}
+  citizens.npc.limit.55: {default: false}
+  citizens.npc.limit.56: {default: false}
+  citizens.npc.limit.57: {default: false}
+  citizens.npc.limit.58: {default: false}
+  citizens.npc.limit.59: {default: false}
+  citizens.npc.limit.60: {default: false}
+  citizens.npc.limit.61: {default: false}
+  citizens.npc.limit.62: {default: false}
+  citizens.npc.limit.63: {default: false}
+  citizens.npc.limit.64: {default: false}
+  citizens.npc.limit.65: {default: false}
+  citizens.npc.limit.66: {default: false}
+  citizens.npc.limit.67: {default: false}
+  citizens.npc.limit.68: {default: false}
+  citizens.npc.limit.69: {default: false}
+  citizens.npc.limit.70: {default: false}
+  citizens.npc.limit.71: {default: false}
+  citizens.npc.limit.72: {default: false}
+  citizens.npc.limit.73: {default: false}
+  citizens.npc.limit.74: {default: false}
+  citizens.npc.limit.75: {default: false}
+  citizens.npc.limit.76: {default: false}
+  citizens.npc.limit.77: {default: false}
+  citizens.npc.limit.78: {default: false}
+  citizens.npc.limit.79: {default: false}
+  citizens.npc.limit.80: {default: false}
+  citizens.npc.limit.81: {default: false}
+  citizens.npc.limit.82: {default: false}
+  citizens.npc.limit.83: {default: false}
+  citizens.npc.limit.84: {default: false}
+  citizens.npc.limit.85: {default: false}
+  citizens.npc.limit.86: {default: false}
+  citizens.npc.limit.87: {default: false}
+  citizens.npc.limit.88: {default: false}
+  citizens.npc.limit.89: {default: false}
+  citizens.npc.limit.90: {default: false}
+  citizens.npc.limit.91: {default: false}
+  citizens.npc.limit.92: {default: false}
+  citizens.npc.limit.93: {default: false}
+  citizens.npc.limit.94: {default: false}
+  citizens.npc.limit.95: {default: false}
+  citizens.npc.limit.96: {default: false}
+  citizens.npc.limit.97: {default: false}
+  citizens.npc.limit.98: {default: false}
+  citizens.npc.limit.99: {default: false}
+  citizens.npc.limit.100: {default: false}
+  citizens.npc.list: {default: false}
+  citizens.npc.lookclose: {default: false}
+  citizens.npc.moveto: {default: false}
+  citizens.npc.name: {default: false}
+  citizens.npc.ocelot: {default: false}
+  citizens.npc.owner: {default: false}
+  citizens.npc.path: {default: false}
+  citizens.npc.pathfindingrange: {default: false}
+  citizens.npc.playerlist: {default: false}
+  citizens.npc.pose: {default: false}
+  citizens.npc.power: {default: false}
+  citizens.npc.profession: {default: false}
+  citizens.npc.remove: {default: false}
+  citizens.npc.rename: {default: false}
+  citizens.npc.respawn: {default: false}
+  citizens.npc.select: {default: false}
+  citizens.npc.size: {default: false}
+  citizens.npc.skeletontype: {default: false}
+  citizens.npc.spawn: {default: false}
+  citizens.npc.speak: {default: false}
+  citizens.npc.speed: {default: false}
+  citizens.npc.talk: {default: false}
+  citizens.npc.targetable: {default: false}
+  citizens.npc.tp: {default: false}
+  citizens.npc.tphere: {default: false}
+  citizens.npc.tphere.multiworld: {default: false}
+  citizens.npc.tpto: {default: false}
+  citizens.npc.trait-configure: {default: false}
+  citizens.npc.trait-configure.age: {default: false}
+  citizens.npc.trait-configure.anchors: {default: false}
+  citizens.npc.trait-configure.controllable: {default: false}
+  citizens.npc.trait-configure.gravity: {default: false}
+  citizens.npc.trait-configure.horsemodifiers: {default: false}
+  citizens.npc.trait-configure.location: {default: false}
+  citizens.npc.trait-configure.lookclose: {default: false}
+  citizens.npc.trait-configure.ocelotmodifiers: {default: false}
+  citizens.npc.trait-configure.poses: {default: false}
+  citizens.npc.trait-configure.powered: {default: false}
+  citizens.npc.trait-configure.profession: {default: false}
+  citizens.npc.trait-configure.saddle: {default: false}
+  citizens.npc.trait-configure.sheared: {default: false}
+  citizens.npc.trait-configure.skeletontype: {default: false}
+  citizens.npc.trait-configure.slimesize: {default: false}
+  citizens.npc.trait-configure.text: {default: false}
+  citizens.npc.trait-configure.waypoints: {default: false}
+  citizens.npc.trait-configure.wolfmodifiers: {default: false}
+  citizens.npc.trait-configure.woolcolor: {default: false}
+  citizens.npc.trait-configure.zombiemodifier: {default: false}
+  citizens.npc.trait: {default: false}
+  citizens.npc.trait.age: {default: false}
+  citizens.npc.trait.anchors: {default: false}
+  citizens.npc.trait.controllable: {default: false}
+  citizens.npc.trait.gravity: {default: false}
+  citizens.npc.trait.horsemodifiers: {default: false}
+  citizens.npc.trait.location: {default: false}
+  citizens.npc.trait.lookclose: {default: false}
+  citizens.npc.trait.ocelotmodifiers: {default: false}
+  citizens.npc.trait.poses: {default: false}
+  citizens.npc.trait.powered: {default: false}
+  citizens.npc.trait.profession: {default: false}
+  citizens.npc.trait.saddle: {default: false}
+  citizens.npc.trait.sheared: {default: false}
+  citizens.npc.trait.skeletontype: {default: false}
+  citizens.npc.trait.slimesize: {default: false}
+  citizens.npc.trait.text: {default: false}
+  citizens.npc.trait.waypoints: {default: false}
+  citizens.npc.trait.wolfmodifiers: {default: false}
+  citizens.npc.trait.woolcolor: {default: false}
+  citizens.npc.trait.zombiemodifier: {default: false}
+  citizens.npc.type: {default: false}
+  citizens.npc.vulnerable: {default: false}
+  citizens.npc.wolf: {default: false}
+  citizens.npc.zombiemodifier: {default: false}
+  citizens.script.compile: {default: false}
+  citizens.script.help: {default: false}
+  citizens.templates.apply: {default: false}
+  citizens.templates.create: {default: false}
+  citizens.templates.help: {default: false}
+  citizens.trait.help: {default: false}
+  citizens.waypoints.disableteleport: {default: false}
+  citizens.waypoints.help: {default: false}
+  citizens.waypoints.provider: {default: false}
+# -------------------------------------------- #
+# ALIAS
+# -------------------------------------------- #
+  citizens.npc.text:
+    default: false
+    children:
+      citizens.npc.edit.text: true
+# -------------------------------------------- #
+# STAR NOTATION
+# -------------------------------------------- #
   citizens.*:
+    default: false
+    children:
+      citizens.admin: true
+      citizens.admin.avoid-limits: true
+      citizens.admin.remove.all: true
+      citizens.citizens.help: true
+      citizens.help: true
+      citizens.npc.age: true
+      citizens.npc.anchor: true
+      citizens.npc.behaviour: true
+      citizens.npc.controllable: true
+      citizens.npc.controllable.arrow: true
+      citizens.npc.controllable.bat: true
+      citizens.npc.controllable.blaze: true
+      citizens.npc.controllable.boat: true
+      citizens.npc.controllable.cavespider: true
+      citizens.npc.controllable.chicken: true
+      citizens.npc.controllable.complexpart: true
+      citizens.npc.controllable.cow: true
+      citizens.npc.controllable.creeper: true
+      citizens.npc.controllable.droppeditem: true
+      citizens.npc.controllable.egg: true
+      citizens.npc.controllable.endercrystal: true
+      citizens.npc.controllable.enderdragon: true
+      citizens.npc.controllable.enderman: true
+      citizens.npc.controllable.enderpearl: true
+      citizens.npc.controllable.endersignal: true
+      citizens.npc.controllable.experienceorb: true
+      citizens.npc.controllable.fallingblock: true
+      citizens.npc.controllable.fireball: true
+      citizens.npc.controllable.firework: true
+      citizens.npc.controllable.fishinghook: true
+      citizens.npc.controllable.ghast: true
+      citizens.npc.controllable.giant: true
+      citizens.npc.controllable.horse: true
+      citizens.npc.controllable.irongolem: true
+      citizens.npc.controllable.itemframe: true
+      citizens.npc.controllable.leashhitch: true
+      citizens.npc.controllable.lightning: true
+      citizens.npc.controllable.magmacube: true
+      citizens.npc.controllable.minecart: true
+      citizens.npc.controllable.minecartchest: true
+      citizens.npc.controllable.minecartfurnace: true
+      citizens.npc.controllable.minecarthopper: true
+      citizens.npc.controllable.minecartmobspawner: true
+      citizens.npc.controllable.minecarttnt: true
+      citizens.npc.controllable.mushroomcow: true
+      citizens.npc.controllable.ocelot: true
+      citizens.npc.controllable.painting: true
+      citizens.npc.controllable.pig: true
+      citizens.npc.controllable.pigzombie: true
+      citizens.npc.controllable.player: true
+      citizens.npc.controllable.primedtnt: true
+      citizens.npc.controllable.sheep: true
+      citizens.npc.controllable.silverfish: true
+      citizens.npc.controllable.skeleton: true
+      citizens.npc.controllable.slime: true
+      citizens.npc.controllable.smallfireball: true
+      citizens.npc.controllable.snowball: true
+      citizens.npc.controllable.snowman: true
+      citizens.npc.controllable.spider: true
+      citizens.npc.controllable.splashpotion: true
+      citizens.npc.controllable.squid: true
+      citizens.npc.controllable.thrownexpbottle: true
+      citizens.npc.controllable.villager: true
+      citizens.npc.controllable.weather: true
+      citizens.npc.controllable.witch: true
+      citizens.npc.controllable.wither: true
+      citizens.npc.controllable.witherskull: true
+      citizens.npc.controllable.wolf: true
+      citizens.npc.controllable.zombie: true
+      citizens.npc.copy: true
+      citizens.npc.create: true
+      citizens.npc.create.arrow: true
+      citizens.npc.create.bat: true
+      citizens.npc.create.blaze: true
+      citizens.npc.create.boat: true
+      citizens.npc.create.cavespider: true
+      citizens.npc.create.chicken: true
+      citizens.npc.create.complexpart: true
+      citizens.npc.create.cow: true
+      citizens.npc.create.creeper: true
+      citizens.npc.create.droppeditem: true
+      citizens.npc.create.egg: true
+      citizens.npc.create.endercrystal: true
+      citizens.npc.create.enderdragon: true
+      citizens.npc.create.enderman: true
+      citizens.npc.create.enderpearl: true
+      citizens.npc.create.endersignal: true
+      citizens.npc.create.experienceorb: true
+      citizens.npc.create.fallingblock: true
+      citizens.npc.create.fireball: true
+      citizens.npc.create.firework: true
+      citizens.npc.create.fishinghook: true
+      citizens.npc.create.ghast: true
+      citizens.npc.create.giant: true
+      citizens.npc.create.horse: true
+      citizens.npc.create.irongolem: true
+      citizens.npc.create.itemframe: true
+      citizens.npc.create.leashhitch: true
+      citizens.npc.create.lightning: true
+      citizens.npc.create.magmacube: true
+      citizens.npc.create.minecart: true
+      citizens.npc.create.minecartchest: true
+      citizens.npc.create.minecartfurnace: true
+      citizens.npc.create.minecarthopper: true
+      citizens.npc.create.minecartmobspawner: true
+      citizens.npc.create.minecarttnt: true
+      citizens.npc.create.mushroomcow: true
+      citizens.npc.create.ocelot: true
+      citizens.npc.create.painting: true
+      citizens.npc.create.pig: true
+      citizens.npc.create.pigzombie: true
+      citizens.npc.create.player: true
+      citizens.npc.create.primedtnt: true
+      citizens.npc.create.sheep: true
+      citizens.npc.create.silverfish: true
+      citizens.npc.create.skeleton: true
+      citizens.npc.create.slime: true
+      citizens.npc.create.smallfireball: true
+      citizens.npc.create.snowball: true
+      citizens.npc.create.snowman: true
+      citizens.npc.create.spider: true
+      citizens.npc.create.splashpotion: true
+      citizens.npc.create.squid: true
+      citizens.npc.create.thrownexpbottle: true
+      citizens.npc.create.villager: true
+      citizens.npc.create.weather: true
+      citizens.npc.create.witch: true
+      citizens.npc.create.wither: true
+      citizens.npc.create.witherskull: true
+      citizens.npc.create.wolf: true
+      citizens.npc.create.zombie: true
+      citizens.npc.despawn: true
+      citizens.npc.edit.copier: true
+      citizens.npc.edit.equip: true
+      citizens.npc.edit.path: true
+      citizens.npc.edit.text: true
+      citizens.npc.gravity: true
+      citizens.npc.help: true
+      citizens.npc.help: true
+      citizens.npc.horse: true
+      citizens.npc.ignore-cost: true
+      citizens.npc.info: true
+      citizens.npc.leashable: true
+      citizens.npc.limit.1: true
+      citizens.npc.limit.2: true
+      citizens.npc.limit.3: true
+      citizens.npc.limit.4: true
+      citizens.npc.limit.5: true
+      citizens.npc.limit.6: true
+      citizens.npc.limit.7: true
+      citizens.npc.limit.8: true
+      citizens.npc.limit.9: true
+      citizens.npc.limit.10: true
+      citizens.npc.limit.11: true
+      citizens.npc.limit.12: true
+      citizens.npc.limit.13: true
+      citizens.npc.limit.14: true
+      citizens.npc.limit.15: true
+      citizens.npc.limit.16: true
+      citizens.npc.limit.17: true
+      citizens.npc.limit.18: true
+      citizens.npc.limit.19: true
+      citizens.npc.limit.20: true
+      citizens.npc.limit.21: true
+      citizens.npc.limit.22: true
+      citizens.npc.limit.23: true
+      citizens.npc.limit.24: true
+      citizens.npc.limit.25: true
+      citizens.npc.limit.26: true
+      citizens.npc.limit.27: true
+      citizens.npc.limit.28: true
+      citizens.npc.limit.29: true
+      citizens.npc.limit.30: true
+      citizens.npc.limit.31: true
+      citizens.npc.limit.32: true
+      citizens.npc.limit.33: true
+      citizens.npc.limit.34: true
+      citizens.npc.limit.35: true
+      citizens.npc.limit.36: true
+      citizens.npc.limit.37: true
+      citizens.npc.limit.38: true
+      citizens.npc.limit.39: true
+      citizens.npc.limit.40: true
+      citizens.npc.limit.41: true
+      citizens.npc.limit.42: true
+      citizens.npc.limit.43: true
+      citizens.npc.limit.44: true
+      citizens.npc.limit.45: true
+      citizens.npc.limit.46: true
+      citizens.npc.limit.47: true
+      citizens.npc.limit.48: true
+      citizens.npc.limit.49: true
+      citizens.npc.limit.50: true
+      citizens.npc.limit.51: true
+      citizens.npc.limit.52: true
+      citizens.npc.limit.53: true
+      citizens.npc.limit.54: true
+      citizens.npc.limit.55: true
+      citizens.npc.limit.56: true
+      citizens.npc.limit.57: true
+      citizens.npc.limit.58: true
+      citizens.npc.limit.59: true
+      citizens.npc.limit.60: true
+      citizens.npc.limit.61: true
+      citizens.npc.limit.62: true
+      citizens.npc.limit.63: true
+      citizens.npc.limit.64: true
+      citizens.npc.limit.65: true
+      citizens.npc.limit.66: true
+      citizens.npc.limit.67: true
+      citizens.npc.limit.68: true
+      citizens.npc.limit.69: true
+      citizens.npc.limit.70: true
+      citizens.npc.limit.71: true
+      citizens.npc.limit.72: true
+      citizens.npc.limit.73: true
+      citizens.npc.limit.74: true
+      citizens.npc.limit.75: true
+      citizens.npc.limit.76: true
+      citizens.npc.limit.77: true
+      citizens.npc.limit.78: true
+      citizens.npc.limit.79: true
+      citizens.npc.limit.80: true
+      citizens.npc.limit.81: true
+      citizens.npc.limit.82: true
+      citizens.npc.limit.83: true
+      citizens.npc.limit.84: true
+      citizens.npc.limit.85: true
+      citizens.npc.limit.86: true
+      citizens.npc.limit.87: true
+      citizens.npc.limit.88: true
+      citizens.npc.limit.89: true
+      citizens.npc.limit.90: true
+      citizens.npc.limit.91: true
+      citizens.npc.limit.92: true
+      citizens.npc.limit.93: true
+      citizens.npc.limit.94: true
+      citizens.npc.limit.95: true
+      citizens.npc.limit.96: true
+      citizens.npc.limit.97: true
+      citizens.npc.limit.98: true
+      citizens.npc.limit.99: true
+      citizens.npc.limit.100: true
+      citizens.npc.list: true
+      citizens.npc.lookclose: true
+      citizens.npc.moveto: true
+      citizens.npc.name: true
+      citizens.npc.ocelot: true
+      citizens.npc.owner: true
+      citizens.npc.path: true
+      citizens.npc.pathfindingrange: true
+      citizens.npc.playerlist: true
+      citizens.npc.pose: true
+      citizens.npc.power: true
+      citizens.npc.profession: true
+      citizens.npc.remove: true
+      citizens.npc.rename: true
+      citizens.npc.respawn: true
+      citizens.npc.select: true
+      citizens.npc.size: true
+      citizens.npc.skeletontype: true
+      citizens.npc.spawn: true
+      citizens.npc.speak: true
+      citizens.npc.speed: true
+      citizens.npc.talk: true
+      citizens.npc.targetable: true
+      citizens.npc.tp: true
+      citizens.npc.tphere: true
+      citizens.npc.tphere.multiworld: true
+      citizens.npc.tpto: true
+      citizens.npc.trait-configure: true
+      citizens.npc.trait-configure.age: true
+      citizens.npc.trait-configure.anchors: true
+      citizens.npc.trait-configure.controllable: true
+      citizens.npc.trait-configure.gravity: true
+      citizens.npc.trait-configure.horsemodifiers: true
+      citizens.npc.trait-configure.location: true
+      citizens.npc.trait-configure.lookclose: true
+      citizens.npc.trait-configure.ocelotmodifiers: true
+      citizens.npc.trait-configure.poses: true
+      citizens.npc.trait-configure.powered: true
+      citizens.npc.trait-configure.profession: true
+      citizens.npc.trait-configure.saddle: true
+      citizens.npc.trait-configure.sheared: true
+      citizens.npc.trait-configure.skeletontype: true
+      citizens.npc.trait-configure.slimesize: true
+      citizens.npc.trait-configure.text: true
+      citizens.npc.trait-configure.waypoints: true
+      citizens.npc.trait-configure.wolfmodifiers: true
+      citizens.npc.trait-configure.woolcolor: true
+      citizens.npc.trait-configure.zombiemodifier: true
+      citizens.npc.trait: true
+      citizens.npc.trait.age: true
+      citizens.npc.trait.anchors: true
+      citizens.npc.trait.controllable: true
+      citizens.npc.trait.gravity: true
+      citizens.npc.trait.horsemodifiers: true
+      citizens.npc.trait.location: true
+      citizens.npc.trait.lookclose: true
+      citizens.npc.trait.ocelotmodifiers: true
+      citizens.npc.trait.poses: true
+      citizens.npc.trait.powered: true
+      citizens.npc.trait.profession: true
+      citizens.npc.trait.saddle: true
+      citizens.npc.trait.sheared: true
+      citizens.npc.trait.skeletontype: true
+      citizens.npc.trait.slimesize: true
+      citizens.npc.trait.text: true
+      citizens.npc.trait.waypoints: true
+      citizens.npc.trait.wolfmodifiers: true
+      citizens.npc.trait.woolcolor: true
+      citizens.npc.trait.zombiemodifier: true
+      citizens.npc.type: true
+      citizens.npc.vulnerable: true
+      citizens.npc.wolf: true
+      citizens.npc.zombiemodifier: true
+      citizens.script.compile: true
+      citizens.script.help: true
+      citizens.templates.apply: true
+      citizens.templates.create: true
+      citizens.templates.help: true
+      citizens.trait.help: true
+      citizens.waypoints.disableteleport: true
+      citizens.waypoints.help: true
+      citizens.waypoints.provider: true
+  citizens.admin.*:
+    default: false
+    children:
+      citizens.admin.avoid-limits: true
+      citizens.admin.remove.all: true
+  citizens.citizens.*:
+    default: false
+    children:
+      citizens.citizens.help: true
+  citizens.npc.*:
+    default: false
+    children:
+      citizens.npc.age: true
+      citizens.npc.anchor: true
+      citizens.npc.behaviour: true
+      citizens.npc.controllable: true
+      citizens.npc.controllable.arrow: true
+      citizens.npc.controllable.bat: true
+      citizens.npc.controllable.blaze: true
+      citizens.npc.controllable.boat: true
+      citizens.npc.controllable.cavespider: true
+      citizens.npc.controllable.chicken: true
+      citizens.npc.controllable.complexpart: true
+      citizens.npc.controllable.cow: true
+      citizens.npc.controllable.creeper: true
+      citizens.npc.controllable.droppeditem: true
+      citizens.npc.controllable.egg: true
+      citizens.npc.controllable.endercrystal: true
+      citizens.npc.controllable.enderdragon: true
+      citizens.npc.controllable.enderman: true
+      citizens.npc.controllable.enderpearl: true
+      citizens.npc.controllable.endersignal: true
+      citizens.npc.controllable.experienceorb: true
+      citizens.npc.controllable.fallingblock: true
+      citizens.npc.controllable.fireball: true
+      citizens.npc.controllable.firework: true
+      citizens.npc.controllable.fishinghook: true
+      citizens.npc.controllable.ghast: true
+      citizens.npc.controllable.giant: true
+      citizens.npc.controllable.horse: true
+      citizens.npc.controllable.irongolem: true
+      citizens.npc.controllable.itemframe: true
+      citizens.npc.controllable.leashhitch: true
+      citizens.npc.controllable.lightning: true
+      citizens.npc.controllable.magmacube: true
+      citizens.npc.controllable.minecart: true
+      citizens.npc.controllable.minecartchest: true
+      citizens.npc.controllable.minecartfurnace: true
+      citizens.npc.controllable.minecarthopper: true
+      citizens.npc.controllable.minecartmobspawner: true
+      citizens.npc.controllable.minecarttnt: true
+      citizens.npc.controllable.mushroomcow: true
+      citizens.npc.controllable.ocelot: true
+      citizens.npc.controllable.painting: true
+      citizens.npc.controllable.pig: true
+      citizens.npc.controllable.pigzombie: true
+      citizens.npc.controllable.player: true
+      citizens.npc.controllable.primedtnt: true
+      citizens.npc.controllable.sheep: true
+      citizens.npc.controllable.silverfish: true
+      citizens.npc.controllable.skeleton: true
+      citizens.npc.controllable.slime: true
+      citizens.npc.controllable.smallfireball: true
+      citizens.npc.controllable.snowball: true
+      citizens.npc.controllable.snowman: true
+      citizens.npc.controllable.spider: true
+      citizens.npc.controllable.splashpotion: true
+      citizens.npc.controllable.squid: true
+      citizens.npc.controllable.thrownexpbottle: true
+      citizens.npc.controllable.villager: true
+      citizens.npc.controllable.weather: true
+      citizens.npc.controllable.witch: true
+      citizens.npc.controllable.wither: true
+      citizens.npc.controllable.witherskull: true
+      citizens.npc.controllable.wolf: true
+      citizens.npc.controllable.zombie: true
+      citizens.npc.copy: true
+      citizens.npc.create: true
+      citizens.npc.create.arrow: true
+      citizens.npc.create.bat: true
+      citizens.npc.create.blaze: true
+      citizens.npc.create.boat: true
+      citizens.npc.create.cavespider: true
+      citizens.npc.create.chicken: true
+      citizens.npc.create.complexpart: true
+      citizens.npc.create.cow: true
+      citizens.npc.create.creeper: true
+      citizens.npc.create.droppeditem: true
+      citizens.npc.create.egg: true
+      citizens.npc.create.endercrystal: true
+      citizens.npc.create.enderdragon: true
+      citizens.npc.create.enderman: true
+      citizens.npc.create.enderpearl: true
+      citizens.npc.create.endersignal: true
+      citizens.npc.create.experienceorb: true
+      citizens.npc.create.fallingblock: true
+      citizens.npc.create.fireball: true
+      citizens.npc.create.firework: true
+      citizens.npc.create.fishinghook: true
+      citizens.npc.create.ghast: true
+      citizens.npc.create.giant: true
+      citizens.npc.create.horse: true
+      citizens.npc.create.irongolem: true
+      citizens.npc.create.itemframe: true
+      citizens.npc.create.leashhitch: true
+      citizens.npc.create.lightning: true
+      citizens.npc.create.magmacube: true
+      citizens.npc.create.minecart: true
+      citizens.npc.create.minecartchest: true
+      citizens.npc.create.minecartfurnace: true
+      citizens.npc.create.minecarthopper: true
+      citizens.npc.create.minecartmobspawner: true
+      citizens.npc.create.minecarttnt: true
+      citizens.npc.create.mushroomcow: true
+      citizens.npc.create.ocelot: true
+      citizens.npc.create.painting: true
+      citizens.npc.create.pig: true
+      citizens.npc.create.pigzombie: true
+      citizens.npc.create.player: true
+      citizens.npc.create.primedtnt: true
+      citizens.npc.create.sheep: true
+      citizens.npc.create.silverfish: true
+      citizens.npc.create.skeleton: true
+      citizens.npc.create.slime: true
+      citizens.npc.create.smallfireball: true
+      citizens.npc.create.snowball: true
+      citizens.npc.create.snowman: true
+      citizens.npc.create.spider: true
+      citizens.npc.create.splashpotion: true
+      citizens.npc.create.squid: true
+      citizens.npc.create.thrownexpbottle: true
+      citizens.npc.create.villager: true
+      citizens.npc.create.weather: true
+      citizens.npc.create.witch: true
+      citizens.npc.create.wither: true
+      citizens.npc.create.witherskull: true
+      citizens.npc.create.wolf: true
+      citizens.npc.create.zombie: true
+      citizens.npc.despawn: true
+      citizens.npc.edit.copier: true
+      citizens.npc.edit.equip: true
+      citizens.npc.edit.path: true
+      citizens.npc.edit.text: true
+      citizens.npc.gravity: true
+      citizens.npc.help: true
+      citizens.npc.help: true
+      citizens.npc.horse: true
+      citizens.npc.ignore-cost: true
+      citizens.npc.info: true
+      citizens.npc.leashable: true
+      citizens.npc.limit.1: true
+      citizens.npc.limit.2: true
+      citizens.npc.limit.3: true
+      citizens.npc.limit.4: true
+      citizens.npc.limit.5: true
+      citizens.npc.limit.6: true
+      citizens.npc.limit.7: true
+      citizens.npc.limit.8: true
+      citizens.npc.limit.9: true
+      citizens.npc.limit.10: true
+      citizens.npc.limit.11: true
+      citizens.npc.limit.12: true
+      citizens.npc.limit.13: true
+      citizens.npc.limit.14: true
+      citizens.npc.limit.15: true
+      citizens.npc.limit.16: true
+      citizens.npc.limit.17: true
+      citizens.npc.limit.18: true
+      citizens.npc.limit.19: true
+      citizens.npc.limit.20: true
+      citizens.npc.limit.21: true
+      citizens.npc.limit.22: true
+      citizens.npc.limit.23: true
+      citizens.npc.limit.24: true
+      citizens.npc.limit.25: true
+      citizens.npc.limit.26: true
+      citizens.npc.limit.27: true
+      citizens.npc.limit.28: true
+      citizens.npc.limit.29: true
+      citizens.npc.limit.30: true
+      citizens.npc.limit.31: true
+      citizens.npc.limit.32: true
+      citizens.npc.limit.33: true
+      citizens.npc.limit.34: true
+      citizens.npc.limit.35: true
+      citizens.npc.limit.36: true
+      citizens.npc.limit.37: true
+      citizens.npc.limit.38: true
+      citizens.npc.limit.39: true
+      citizens.npc.limit.40: true
+      citizens.npc.limit.41: true
+      citizens.npc.limit.42: true
+      citizens.npc.limit.43: true
+      citizens.npc.limit.44: true
+      citizens.npc.limit.45: true
+      citizens.npc.limit.46: true
+      citizens.npc.limit.47: true
+      citizens.npc.limit.48: true
+      citizens.npc.limit.49: true
+      citizens.npc.limit.50: true
+      citizens.npc.limit.51: true
+      citizens.npc.limit.52: true
+      citizens.npc.limit.53: true
+      citizens.npc.limit.54: true
+      citizens.npc.limit.55: true
+      citizens.npc.limit.56: true
+      citizens.npc.limit.57: true
+      citizens.npc.limit.58: true
+      citizens.npc.limit.59: true
+      citizens.npc.limit.60: true
+      citizens.npc.limit.61: true
+      citizens.npc.limit.62: true
+      citizens.npc.limit.63: true
+      citizens.npc.limit.64: true
+      citizens.npc.limit.65: true
+      citizens.npc.limit.66: true
+      citizens.npc.limit.67: true
+      citizens.npc.limit.68: true
+      citizens.npc.limit.69: true
+      citizens.npc.limit.70: true
+      citizens.npc.limit.71: true
+      citizens.npc.limit.72: true
+      citizens.npc.limit.73: true
+      citizens.npc.limit.74: true
+      citizens.npc.limit.75: true
+      citizens.npc.limit.76: true
+      citizens.npc.limit.77: true
+      citizens.npc.limit.78: true
+      citizens.npc.limit.79: true
+      citizens.npc.limit.80: true
+      citizens.npc.limit.81: true
+      citizens.npc.limit.82: true
+      citizens.npc.limit.83: true
+      citizens.npc.limit.84: true
+      citizens.npc.limit.85: true
+      citizens.npc.limit.86: true
+      citizens.npc.limit.87: true
+      citizens.npc.limit.88: true
+      citizens.npc.limit.89: true
+      citizens.npc.limit.90: true
+      citizens.npc.limit.91: true
+      citizens.npc.limit.92: true
+      citizens.npc.limit.93: true
+      citizens.npc.limit.94: true
+      citizens.npc.limit.95: true
+      citizens.npc.limit.96: true
+      citizens.npc.limit.97: true
+      citizens.npc.limit.98: true
+      citizens.npc.limit.99: true
+      citizens.npc.limit.100: true
+      citizens.npc.list: true
+      citizens.npc.lookclose: true
+      citizens.npc.moveto: true
+      citizens.npc.name: true
+      citizens.npc.ocelot: true
+      citizens.npc.owner: true
+      citizens.npc.path: true
+      citizens.npc.pathfindingrange: true
+      citizens.npc.playerlist: true
+      citizens.npc.pose: true
+      citizens.npc.power: true
+      citizens.npc.profession: true
+      citizens.npc.remove: true
+      citizens.npc.rename: true
+      citizens.npc.respawn: true
+      citizens.npc.select: true
+      citizens.npc.size: true
+      citizens.npc.skeletontype: true
+      citizens.npc.spawn: true
+      citizens.npc.speak: true
+      citizens.npc.speed: true
+      citizens.npc.talk: true
+      citizens.npc.targetable: true
+      citizens.npc.tp: true
+      citizens.npc.tphere: true
+      citizens.npc.tphere.multiworld: true
+      citizens.npc.tpto: true
+      citizens.npc.trait-configure: true
+      citizens.npc.trait-configure.age: true
+      citizens.npc.trait-configure.anchors: true
+      citizens.npc.trait-configure.controllable: true
+      citizens.npc.trait-configure.gravity: true
+      citizens.npc.trait-configure.horsemodifiers: true
+      citizens.npc.trait-configure.location: true
+      citizens.npc.trait-configure.lookclose: true
+      citizens.npc.trait-configure.ocelotmodifiers: true
+      citizens.npc.trait-configure.poses: true
+      citizens.npc.trait-configure.powered: true
+      citizens.npc.trait-configure.profession: true
+      citizens.npc.trait-configure.saddle: true
+      citizens.npc.trait-configure.sheared: true
+      citizens.npc.trait-configure.skeletontype: true
+      citizens.npc.trait-configure.slimesize: true
+      citizens.npc.trait-configure.text: true
+      citizens.npc.trait-configure.waypoints: true
+      citizens.npc.trait-configure.wolfmodifiers: true
+      citizens.npc.trait-configure.woolcolor: true
+      citizens.npc.trait-configure.zombiemodifier: true
+      citizens.npc.trait: true
+      citizens.npc.trait.age: true
+      citizens.npc.trait.anchors: true
+      citizens.npc.trait.controllable: true
+      citizens.npc.trait.gravity: true
+      citizens.npc.trait.horsemodifiers: true
+      citizens.npc.trait.location: true
+      citizens.npc.trait.lookclose: true
+      citizens.npc.trait.ocelotmodifiers: true
+      citizens.npc.trait.poses: true
+      citizens.npc.trait.powered: true
+      citizens.npc.trait.profession: true
+      citizens.npc.trait.saddle: true
+      citizens.npc.trait.sheared: true
+      citizens.npc.trait.skeletontype: true
+      citizens.npc.trait.slimesize: true
+      citizens.npc.trait.text: true
+      citizens.npc.trait.waypoints: true
+      citizens.npc.trait.wolfmodifiers: true
+      citizens.npc.trait.woolcolor: true
+      citizens.npc.trait.zombiemodifier: true
+      citizens.npc.type: true
+      citizens.npc.vulnerable: true
+      citizens.npc.wolf: true
+      citizens.npc.zombiemodifier: true
+  citizens.npc.controllable.*:
+    default: false
+    children:
+      citizens.npc.controllable.arrow: true
+      citizens.npc.controllable.bat: true
+      citizens.npc.controllable.blaze: true
+      citizens.npc.controllable.boat: true
+      citizens.npc.controllable.cavespider: true
+      citizens.npc.controllable.chicken: true
+      citizens.npc.controllable.complexpart: true
+      citizens.npc.controllable.cow: true
+      citizens.npc.controllable.creeper: true
+      citizens.npc.controllable.droppeditem: true
+      citizens.npc.controllable.egg: true
+      citizens.npc.controllable.endercrystal: true
+      citizens.npc.controllable.enderdragon: true
+      citizens.npc.controllable.enderman: true
+      citizens.npc.controllable.enderpearl: true
+      citizens.npc.controllable.endersignal: true
+      citizens.npc.controllable.experienceorb: true
+      citizens.npc.controllable.fallingblock: true
+      citizens.npc.controllable.fireball: true
+      citizens.npc.controllable.firework: true
+      citizens.npc.controllable.fishinghook: true
+      citizens.npc.controllable.ghast: true
+      citizens.npc.controllable.giant: true
+      citizens.npc.controllable.horse: true
+      citizens.npc.controllable.irongolem: true
+      citizens.npc.controllable.itemframe: true
+      citizens.npc.controllable.leashhitch: true
+      citizens.npc.controllable.lightning: true
+      citizens.npc.controllable.magmacube: true
+      citizens.npc.controllable.minecart: true
+      citizens.npc.controllable.minecartchest: true
+      citizens.npc.controllable.minecartfurnace: true
+      citizens.npc.controllable.minecarthopper: true
+      citizens.npc.controllable.minecartmobspawner: true
+      citizens.npc.controllable.minecarttnt: true
+      citizens.npc.controllable.mushroomcow: true
+      citizens.npc.controllable.ocelot: true
+      citizens.npc.controllable.painting: true
+      citizens.npc.controllable.pig: true
+      citizens.npc.controllable.pigzombie: true
+      citizens.npc.controllable.player: true
+      citizens.npc.controllable.primedtnt: true
+      citizens.npc.controllable.sheep: true
+      citizens.npc.controllable.silverfish: true
+      citizens.npc.controllable.skeleton: true
+      citizens.npc.controllable.slime: true
+      citizens.npc.controllable.smallfireball: true
+      citizens.npc.controllable.snowball: true
+      citizens.npc.controllable.snowman: true
+      citizens.npc.controllable.spider: true
+      citizens.npc.controllable.splashpotion: true
+      citizens.npc.controllable.squid: true
+      citizens.npc.controllable.thrownexpbottle: true
+      citizens.npc.controllable.villager: true
+      citizens.npc.controllable.weather: true
+      citizens.npc.controllable.witch: true
+      citizens.npc.controllable.wither: true
+      citizens.npc.controllable.witherskull: true
+      citizens.npc.controllable.wolf: true
+      citizens.npc.controllable.zombie: true
+  citizens.npc.create.*:
+    default: false
+    children:
+      citizens.npc.create.arrow: true
+      citizens.npc.create.bat: true
+      citizens.npc.create.blaze: true
+      citizens.npc.create.boat: true
+      citizens.npc.create.cavespider: true
+      citizens.npc.create.chicken: true
+      citizens.npc.create.complexpart: true
+      citizens.npc.create.cow: true
+      citizens.npc.create.creeper: true
+      citizens.npc.create.droppeditem: true
+      citizens.npc.create.egg: true
+      citizens.npc.create.endercrystal: true
+      citizens.npc.create.enderdragon: true
+      citizens.npc.create.enderman: true
+      citizens.npc.create.enderpearl: true
+      citizens.npc.create.endersignal: true
+      citizens.npc.create.experienceorb: true
+      citizens.npc.create.fallingblock: true
+      citizens.npc.create.fireball: true
+      citizens.npc.create.firework: true
+      citizens.npc.create.fishinghook: true
+      citizens.npc.create.ghast: true
+      citizens.npc.create.giant: true
+      citizens.npc.create.horse: true
+      citizens.npc.create.irongolem: true
+      citizens.npc.create.itemframe: true
+      citizens.npc.create.leashhitch: true
+      citizens.npc.create.lightning: true
+      citizens.npc.create.magmacube: true
+      citizens.npc.create.minecart: true
+      citizens.npc.create.minecartchest: true
+      citizens.npc.create.minecartfurnace: true
+      citizens.npc.create.minecarthopper: true
+      citizens.npc.create.minecartmobspawner: true
+      citizens.npc.create.minecarttnt: true
+      citizens.npc.create.mushroomcow: true
+      citizens.npc.create.ocelot: true
+      citizens.npc.create.painting: true
+      citizens.npc.create.pig: true
+      citizens.npc.create.pigzombie: true
+      citizens.npc.create.player: true
+      citizens.npc.create.primedtnt: true
+      citizens.npc.create.sheep: true
+      citizens.npc.create.silverfish: true
+      citizens.npc.create.skeleton: true
+      citizens.npc.create.slime: true
+      citizens.npc.create.smallfireball: true
+      citizens.npc.create.snowball: true
+      citizens.npc.create.snowman: true
+      citizens.npc.create.spider: true
+      citizens.npc.create.splashpotion: true
+      citizens.npc.create.squid: true
+      citizens.npc.create.thrownexpbottle: true
+      citizens.npc.create.villager: true
+      citizens.npc.create.weather: true
+      citizens.npc.create.witch: true
+      citizens.npc.create.wither: true
+      citizens.npc.create.witherskull: true
+      citizens.npc.create.wolf: true
+      citizens.npc.create.zombie: true
+  citizens.npc.edit.*:
+    default: false
+    children:
+      citizens.npc.edit.copier: true
+      citizens.npc.edit.equip: true
+      citizens.npc.edit.path: true
+      citizens.npc.edit.text: true
+  citizens.npc.limit.*:
+    default: false
+    children:
+      citizens.npc.limit.1: true
+      citizens.npc.limit.2: true
+      citizens.npc.limit.3: true
+      citizens.npc.limit.4: true
+      citizens.npc.limit.5: true
+      citizens.npc.limit.6: true
+      citizens.npc.limit.7: true
+      citizens.npc.limit.8: true
+      citizens.npc.limit.9: true
+      citizens.npc.limit.10: true
+      citizens.npc.limit.11: true
+      citizens.npc.limit.12: true
+      citizens.npc.limit.13: true
+      citizens.npc.limit.14: true
+      citizens.npc.limit.15: true
+      citizens.npc.limit.16: true
+      citizens.npc.limit.17: true
+      citizens.npc.limit.18: true
+      citizens.npc.limit.19: true
+      citizens.npc.limit.20: true
+      citizens.npc.limit.21: true
+      citizens.npc.limit.22: true
+      citizens.npc.limit.23: true
+      citizens.npc.limit.24: true
+      citizens.npc.limit.25: true
+      citizens.npc.limit.26: true
+      citizens.npc.limit.27: true
+      citizens.npc.limit.28: true
+      citizens.npc.limit.29: true
+      citizens.npc.limit.30: true
+      citizens.npc.limit.31: true
+      citizens.npc.limit.32: true
+      citizens.npc.limit.33: true
+      citizens.npc.limit.34: true
+      citizens.npc.limit.35: true
+      citizens.npc.limit.36: true
+      citizens.npc.limit.37: true
+      citizens.npc.limit.38: true
+      citizens.npc.limit.39: true
+      citizens.npc.limit.40: true
+      citizens.npc.limit.41: true
+      citizens.npc.limit.42: true
+      citizens.npc.limit.43: true
+      citizens.npc.limit.44: true
+      citizens.npc.limit.45: true
+      citizens.npc.limit.46: true
+      citizens.npc.limit.47: true
+      citizens.npc.limit.48: true
+      citizens.npc.limit.49: true
+      citizens.npc.limit.50: true
+      citizens.npc.limit.51: true
+      citizens.npc.limit.52: true
+      citizens.npc.limit.53: true
+      citizens.npc.limit.54: true
+      citizens.npc.limit.55: true
+      citizens.npc.limit.56: true
+      citizens.npc.limit.57: true
+      citizens.npc.limit.58: true
+      citizens.npc.limit.59: true
+      citizens.npc.limit.60: true
+      citizens.npc.limit.61: true
+      citizens.npc.limit.62: true
+      citizens.npc.limit.63: true
+      citizens.npc.limit.64: true
+      citizens.npc.limit.65: true
+      citizens.npc.limit.66: true
+      citizens.npc.limit.67: true
+      citizens.npc.limit.68: true
+      citizens.npc.limit.69: true
+      citizens.npc.limit.70: true
+      citizens.npc.limit.71: true
+      citizens.npc.limit.72: true
+      citizens.npc.limit.73: true
+      citizens.npc.limit.74: true
+      citizens.npc.limit.75: true
+      citizens.npc.limit.76: true
+      citizens.npc.limit.77: true
+      citizens.npc.limit.78: true
+      citizens.npc.limit.79: true
+      citizens.npc.limit.80: true
+      citizens.npc.limit.81: true
+      citizens.npc.limit.82: true
+      citizens.npc.limit.83: true
+      citizens.npc.limit.84: true
+      citizens.npc.limit.85: true
+      citizens.npc.limit.86: true
+      citizens.npc.limit.87: true
+      citizens.npc.limit.88: true
+      citizens.npc.limit.89: true
+      citizens.npc.limit.90: true
+      citizens.npc.limit.91: true
+      citizens.npc.limit.92: true
+      citizens.npc.limit.93: true
+      citizens.npc.limit.94: true
+      citizens.npc.limit.95: true
+      citizens.npc.limit.96: true
+      citizens.npc.limit.97: true
+      citizens.npc.limit.98: true
+      citizens.npc.limit.99: true
+      citizens.npc.limit.100: true
+  citizens.npc.tphere.*:
+    default: false
+    children:
+      citizens.npc.tphere.multiworld: true
+  citizens.npc.trait-configure.*:
+    default: false
+    children:
+      citizens.npc.trait-configure.age: true
+      citizens.npc.trait-configure.anchors: true
+      citizens.npc.trait-configure.controllable: true
+      citizens.npc.trait-configure.gravity: true
+      citizens.npc.trait-configure.horsemodifiers: true
+      citizens.npc.trait-configure.location: true
+      citizens.npc.trait-configure.lookclose: true
+      citizens.npc.trait-configure.ocelotmodifiers: true
+      citizens.npc.trait-configure.poses: true
+      citizens.npc.trait-configure.powered: true
+      citizens.npc.trait-configure.profession: true
+      citizens.npc.trait-configure.saddle: true
+      citizens.npc.trait-configure.sheared: true
+      citizens.npc.trait-configure.skeletontype: true
+      citizens.npc.trait-configure.slimesize: true
+      citizens.npc.trait-configure.text: true
+      citizens.npc.trait-configure.waypoints: true
+      citizens.npc.trait-configure.wolfmodifiers: true
+      citizens.npc.trait-configure.woolcolor: true
+      citizens.npc.trait-configure.zombiemodifier: true
+  citizens.npc.trait.*:
+    default: false
+    children:
+      citizens.npc.trait.age: true
+      citizens.npc.trait.anchors: true
+      citizens.npc.trait.controllable: true
+      citizens.npc.trait.gravity: true
+      citizens.npc.trait.horsemodifiers: true
+      citizens.npc.trait.location: true
+      citizens.npc.trait.lookclose: true
+      citizens.npc.trait.ocelotmodifiers: true
+      citizens.npc.trait.poses: true
+      citizens.npc.trait.powered: true
+      citizens.npc.trait.profession: true
+      citizens.npc.trait.saddle: true
+      citizens.npc.trait.sheared: true
+      citizens.npc.trait.skeletontype: true
+      citizens.npc.trait.slimesize: true
+      citizens.npc.trait.text: true
+      citizens.npc.trait.waypoints: true
+      citizens.npc.trait.wolfmodifiers: true
+      citizens.npc.trait.woolcolor: true
+      citizens.npc.trait.zombiemodifier: true
+  citizens.script.*:
+    default: false
+    children:
+      citizens.script.compile: true
+      citizens.script.help: true
+  citizens.templates.*:
+    default: false
+    children:
+      citizens.templates.apply: true
+      citizens.templates.create: true
+      citizens.templates.help: true
+  citizens.waypoints.*:
+    default: false
+    children:
+      citizens.waypoints.disableteleport: true
+      citizens.waypoints.help: true
+      citizens.waypoints.provider: true 
+# -------------------------------------------- #
+# KITS
+# -------------------------------------------- #
+  citizens.kit.op:
     default: op
     children:
-      citizens.admin.*:
-        children:
-            citizens.admin: true
-            citizens.admin.avoid-limits: true
-            citizens.admin.remove.all: true
-      citizens.help.*:
-        children:
-            citizens.npc.help: true
-            citizens.trait.help: true
-            citizens.help: true
-            citizens.waypoints.help: true
-            citizens.templates.help: true
-            citizens.citizens.help: true
-            citizens.script.help: true
-      citizens.script.*:
-        children:
-            citizens.script.compile: true
-            citizens.script.help: true
-      citizens.templates.*:
-        children:
-            citizens.templates.apply: true
-            citizens.templates.create: true
-      citizens.waypoints.*:
-        children:
-            citizens.waypoints.disableteleport: true
-            citizens.waypoints.provider: true
-      citizens.npc.*:
-        children:
-          citizens.npc.age: true
-          citizens.npc.anchor: true
-          citizens.npc.behaviour: true
-          citizens.npc.controllable: true
-          citizens.npc.copy: true
-          citizens.npc.create: true
-          citizens.npc.create.*: true
-          citizens.npc.despawn: true
-          citizens.npc.edit.*:
-            children:
-                citizens.npc.edit.equip: true
-                citizens.npc.edit.path: true
-                citizens.npc.edit.text: true
-          citizens.npc.gravity: true
-          citizens.npc.help: true
-          citizens.npc.ignore-cost: true
-          citizens.npc.list: true
-          citizens.npc.lookclose: true
-          citizens.npc.moveto: true
-          citizens.npc.owner: true
-          citizens.npc.path: true
-          citizens.npc.pathfindingrange: true
-          citizens.npc.pose: true
-          citizens.npc.power: true
-          citizens.npc.profession: true
-          citizens.npc.remove: true
-          citizens.npc.rename: true
-          citizens.npc.select: true
-          citizens.npc.size: true
-          citizens.npc.skeletontype: true
-          citizens.npc.spawn: true
-          citizens.npc.speed: true
-          citizens.npc.talk: true
-          citizens.npc.text:
-            children:
-              citizens.npc.edit.text: true
-          citizens.npc.tp: true
-          citizens.npc.tphere: true
-          citizens.npc.tpto: true
-          citizens.npc.trait.*:
-            children:
-                citizens.npc.trait: true
-                citizens.npc.trait-configure: true
-          citizens.npc.vulnerable: true
-          citizens.npc.wolf: true
+      citizens.*: true


### PR DESCRIPTION
In this commit I have registered all permissions used in the source code. I have also manually created all applicable wildcard (.*) nodes. By doing this no external
permission manager plugin is required. Additionally external permission managers that are superperms based will now work without bugs.

This commit is 99% backwards compatible current server configurations. The only change made to the nodes is the removal of underscores in citizens.npc.controllable.*
permissions. This change was made to achieve consistency with citizens.npc.create.\* permissions.

Signed Off By: Olof "Cayorion" Larsson
