### PR TITLE
Add missing permission nodes for a few traits.

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -304,11 +304,14 @@ permissions:
   citizens.npc.trait-configure.age: {default: false}
   citizens.npc.trait-configure.anchors: {default: false}
   citizens.npc.trait-configure.controllable: {default: false}
+  citizens.npc.trait-configure.equipment: {default: false}
   citizens.npc.trait-configure.gravity: {default: false}
   citizens.npc.trait-configure.horsemodifiers: {default: false}
+  citizens.npc.trait-configure.inventory: {default: false}
   citizens.npc.trait-configure.location: {default: false}
   citizens.npc.trait-configure.lookclose: {default: false}
   citizens.npc.trait-configure.ocelotmodifiers: {default: false}
+  citizens.npc.trait-configure.owner: {default: false}
   citizens.npc.trait-configure.poses: {default: false}
   citizens.npc.trait-configure.powered: {default: false}
   citizens.npc.trait-configure.profession: {default: false}
@@ -316,7 +319,10 @@ permissions:
   citizens.npc.trait-configure.sheared: {default: false}
   citizens.npc.trait-configure.skeletontype: {default: false}
   citizens.npc.trait-configure.slimesize: {default: false}
+  citizens.npc.trait-configure.spawned: {default: false}
+  citizens.npc.trait-configure.speech: {default: false}
   citizens.npc.trait-configure.text: {default: false}
+  citizens.npc.trait-configure.type: {default: false}
   citizens.npc.trait-configure.waypoints: {default: false}
   citizens.npc.trait-configure.wolfmodifiers: {default: false}
   citizens.npc.trait-configure.woolcolor: {default: false}
@@ -325,11 +331,14 @@ permissions:
   citizens.npc.trait.age: {default: false}
   citizens.npc.trait.anchors: {default: false}
   citizens.npc.trait.controllable: {default: false}
+  citizens.npc.trait.equipment: {default: false}
   citizens.npc.trait.gravity: {default: false}
   citizens.npc.trait.horsemodifiers: {default: false}
+  citizens.npc.trait.inventory: {default: false}
   citizens.npc.trait.location: {default: false}
   citizens.npc.trait.lookclose: {default: false}
   citizens.npc.trait.ocelotmodifiers: {default: false}
+  citizens.npc.trait.owner: {default: false}
   citizens.npc.trait.poses: {default: false}
   citizens.npc.trait.powered: {default: false}
   citizens.npc.trait.profession: {default: false}
@@ -337,7 +346,10 @@ permissions:
   citizens.npc.trait.sheared: {default: false}
   citizens.npc.trait.skeletontype: {default: false}
   citizens.npc.trait.slimesize: {default: false}
+  citizens.npc.trait.spawned: {default: false}
+  citizens.npc.trait.speech: {default: false}
   citizens.npc.trait.text: {default: false}
+  citizens.npc.trait.type: {default: false}
   citizens.npc.trait.waypoints: {default: false}
   citizens.npc.trait.wolfmodifiers: {default: false}
   citizens.npc.trait.woolcolor: {default: false}
@@ -642,11 +654,14 @@ permissions:
       citizens.npc.trait-configure.age: true
       citizens.npc.trait-configure.anchors: true
       citizens.npc.trait-configure.controllable: true
+      citizens.npc.trait-configure.equipment: true
       citizens.npc.trait-configure.gravity: true
       citizens.npc.trait-configure.horsemodifiers: true
+      citizens.npc.trait-configure.inventory: true
       citizens.npc.trait-configure.location: true
       citizens.npc.trait-configure.lookclose: true
       citizens.npc.trait-configure.ocelotmodifiers: true
+      citizens.npc.trait-configure.owner: true
       citizens.npc.trait-configure.poses: true
       citizens.npc.trait-configure.powered: true
       citizens.npc.trait-configure.profession: true
@@ -654,7 +669,10 @@ permissions:
       citizens.npc.trait-configure.sheared: true
       citizens.npc.trait-configure.skeletontype: true
       citizens.npc.trait-configure.slimesize: true
+      citizens.npc.trait-configure.spawned: true
+      citizens.npc.trait-configure.speech: true
       citizens.npc.trait-configure.text: true
+      citizens.npc.trait-configure.type: true
       citizens.npc.trait-configure.waypoints: true
       citizens.npc.trait-configure.wolfmodifiers: true
       citizens.npc.trait-configure.woolcolor: true
@@ -663,11 +681,14 @@ permissions:
       citizens.npc.trait.age: true
       citizens.npc.trait.anchors: true
       citizens.npc.trait.controllable: true
+      citizens.npc.trait.equipment: true
       citizens.npc.trait.gravity: true
       citizens.npc.trait.horsemodifiers: true
+      citizens.npc.trait.inventory: true
       citizens.npc.trait.location: true
       citizens.npc.trait.lookclose: true
       citizens.npc.trait.ocelotmodifiers: true
+      citizens.npc.trait.owner: true
       citizens.npc.trait.poses: true
       citizens.npc.trait.powered: true
       citizens.npc.trait.profession: true
@@ -675,7 +696,10 @@ permissions:
       citizens.npc.trait.sheared: true
       citizens.npc.trait.skeletontype: true
       citizens.npc.trait.slimesize: true
+      citizens.npc.trait.spawned: true
+      citizens.npc.trait.speech: true
       citizens.npc.trait.text: true
+      citizens.npc.trait.type: true
       citizens.npc.trait.waypoints: true
       citizens.npc.trait.wolfmodifiers: true
       citizens.npc.trait.woolcolor: true
@@ -974,11 +998,14 @@ permissions:
       citizens.npc.trait-configure.age: true
       citizens.npc.trait-configure.anchors: true
       citizens.npc.trait-configure.controllable: true
+      citizens.npc.trait-configure.equipment: true
       citizens.npc.trait-configure.gravity: true
       citizens.npc.trait-configure.horsemodifiers: true
+      citizens.npc.trait-configure.inventory: true
       citizens.npc.trait-configure.location: true
       citizens.npc.trait-configure.lookclose: true
       citizens.npc.trait-configure.ocelotmodifiers: true
+      citizens.npc.trait-configure.owner: true
       citizens.npc.trait-configure.poses: true
       citizens.npc.trait-configure.powered: true
       citizens.npc.trait-configure.profession: true
@@ -986,7 +1013,10 @@ permissions:
       citizens.npc.trait-configure.sheared: true
       citizens.npc.trait-configure.skeletontype: true
       citizens.npc.trait-configure.slimesize: true
+      citizens.npc.trait-configure.spawned: true
+      citizens.npc.trait-configure.speech: true
       citizens.npc.trait-configure.text: true
+      citizens.npc.trait-configure.type: true
       citizens.npc.trait-configure.waypoints: true
       citizens.npc.trait-configure.wolfmodifiers: true
       citizens.npc.trait-configure.woolcolor: true
@@ -995,11 +1025,14 @@ permissions:
       citizens.npc.trait.age: true
       citizens.npc.trait.anchors: true
       citizens.npc.trait.controllable: true
+      citizens.npc.trait.equipment: true
       citizens.npc.trait.gravity: true
       citizens.npc.trait.horsemodifiers: true
+      citizens.npc.trait.inventory: true
       citizens.npc.trait.location: true
       citizens.npc.trait.lookclose: true
       citizens.npc.trait.ocelotmodifiers: true
+      citizens.npc.trait.owner: true
       citizens.npc.trait.poses: true
       citizens.npc.trait.powered: true
       citizens.npc.trait.profession: true
@@ -1007,7 +1040,10 @@ permissions:
       citizens.npc.trait.sheared: true
       citizens.npc.trait.skeletontype: true
       citizens.npc.trait.slimesize: true
+      citizens.npc.trait.spawned: true
+      citizens.npc.trait.speech: true
       citizens.npc.trait.text: true
+      citizens.npc.trait.type: true
       citizens.npc.trait.waypoints: true
       citizens.npc.trait.wolfmodifiers: true
       citizens.npc.trait.woolcolor: true
@@ -1262,11 +1298,14 @@ permissions:
       citizens.npc.trait-configure.age: true
       citizens.npc.trait-configure.anchors: true
       citizens.npc.trait-configure.controllable: true
+      citizens.npc.trait-configure.equipment: true
       citizens.npc.trait-configure.gravity: true
       citizens.npc.trait-configure.horsemodifiers: true
+      citizens.npc.trait-configure.inventory: true
       citizens.npc.trait-configure.location: true
       citizens.npc.trait-configure.lookclose: true
       citizens.npc.trait-configure.ocelotmodifiers: true
+      citizens.npc.trait-configure.owner: true
       citizens.npc.trait-configure.poses: true
       citizens.npc.trait-configure.powered: true
       citizens.npc.trait-configure.profession: true
@@ -1274,7 +1313,10 @@ permissions:
       citizens.npc.trait-configure.sheared: true
       citizens.npc.trait-configure.skeletontype: true
       citizens.npc.trait-configure.slimesize: true
+      citizens.npc.trait-configure.spawned: true
+      citizens.npc.trait-configure.speech: true
       citizens.npc.trait-configure.text: true
+      citizens.npc.trait-configure.type: true
       citizens.npc.trait-configure.waypoints: true
       citizens.npc.trait-configure.wolfmodifiers: true
       citizens.npc.trait-configure.woolcolor: true
@@ -1285,11 +1327,14 @@ permissions:
       citizens.npc.trait.age: true
       citizens.npc.trait.anchors: true
       citizens.npc.trait.controllable: true
+      citizens.npc.trait.equipment: true
       citizens.npc.trait.gravity: true
       citizens.npc.trait.horsemodifiers: true
+      citizens.npc.trait.inventory: true
       citizens.npc.trait.location: true
       citizens.npc.trait.lookclose: true
       citizens.npc.trait.ocelotmodifiers: true
+      citizens.npc.trait.owner: true
       citizens.npc.trait.poses: true
       citizens.npc.trait.powered: true
       citizens.npc.trait.profession: true
@@ -1297,7 +1342,10 @@ permissions:
       citizens.npc.trait.sheared: true
       citizens.npc.trait.skeletontype: true
       citizens.npc.trait.slimesize: true
+      citizens.npc.trait.spawned: true
+      citizens.npc.trait.speech: true
       citizens.npc.trait.text: true
+      citizens.npc.trait.type: true
       citizens.npc.trait.waypoints: true
       citizens.npc.trait.wolfmodifiers: true
       citizens.npc.trait.woolcolor: true


### PR DESCRIPTION
I missed a few traits when creating permission nodes in my previous pull request. In this pull request I have added the missing ones by taking a look in the class "net.citizensnpcs.npc.CitizensTraitFactory".

Signed Off By: Olof "Cayorion" Larsson
