### PR TITLE
Fix NPC renaming to parse colored names

### DIFF
--- a/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -1071,7 +1071,7 @@ public class NPCCommands {
         }
         Location prev = npc.isSpawned() ? npc.getEntity().getLocation() : null;
         npc.despawn(DespawnReason.PENDING_RESPAWN);
-        npc.setName(newName);
+        npc.setName(Colorizer.parseColors(newName));
         if (prev != null)
             npc.spawn(prev);
 


### PR DESCRIPTION
When renaming NPCs, the names do not get colored. For example, "/npc rename &2GreenBean" results in the NPC being named "&2GreenBean" instead of a green-colored "GreenBean" (or as a raw name, "§2GreenBean")
