### PR TITLE
Dont call InteractEvent (left click) when damaged

### DIFF
--- a/src/main/java/net/citizensnpcs/EventListen.java
+++ b/src/main/java/net/citizensnpcs/EventListen.java
@@ -175,14 +175,6 @@ public class EventListen implements Listener {
         if (event instanceof EntityDamageByEntityEvent) {
             NPCDamageByEntityEvent damageEvent = new NPCDamageByEntityEvent(npc, (EntityDamageByEntityEvent) event);
             Bukkit.getPluginManager().callEvent(damageEvent);
-
-            if (!damageEvent.isCancelled() || !(damageEvent.getDamager() instanceof Player))
-                return;
-            Player damager = (Player) damageEvent.getDamager();
-
-            // Call left-click event
-            NPCLeftClickEvent leftClickEvent = new NPCLeftClickEvent(npc, damager);
-            Bukkit.getPluginManager().callEvent(leftClickEvent);
         } else if (event instanceof EntityDamageByBlockEvent) {
             Bukkit.getPluginManager().callEvent(new NPCDamageByBlockEvent(npc, (EntityDamageByBlockEvent) event));
         } else {


### PR DESCRIPTION
Calling a left click event every time the entity is damaged can leed inter plugin compatibility problems.
There is no check if the player actually left clicked the entity and is in range to click the entity.
When plugins use custom damage systems and long range attack spells, it can be that the entity is damaged by a player but the player is not in range.
When a player executes an are of effect attack and damages all NPCs around him all NPCs will fire a left click event, which then may result in the player "interacting" with the NPCs.

This can leed to unexpected results.
