### PR TITLE
Fix NavigationStuckEvent set-null

### DIFF
--- a/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
+++ b/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
@@ -225,12 +225,12 @@ public class CitizensNavigator implements Navigator, Runnable {
             stopNavigating();
             return;
         }
-        if (reason == CancelReason.STUCK && localParams.stuckAction() != null) {
+        if (reason == CancelReason.STUCK) {
             StuckAction action = localParams.stuckAction();
             NavigationStuckEvent event = new NavigationStuckEvent(this, action);
             Bukkit.getPluginManager().callEvent(event);
             action = event.getAction();
-            boolean shouldContinue = action.run(npc, this);
+            boolean shouldContinue = action != null ? action.run(npc, this): false;
             if (shouldContinue) {
                 stationaryTicks = 0;
                 executing.clearCancelReason();


### PR DESCRIPTION
If you set the action in a NavigationStuckEvent, it throws an NPE rather
than simply doing nothing. This patches that.
It also throws the event even when the default stuck action is null.
