### PR TITLE
Fix the sit animation, fixes #96

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 Citizens.jar
 *.lnk
 *.iml
+/.idea
+dependency-reduced-pom.xml

--- a/src/main/java/net/citizensnpcs/util/PlayerAnimation.java
+++ b/src/main/java/net/citizensnpcs/util/PlayerAnimation.java
@@ -52,10 +52,11 @@ public enum PlayerAnimation {
         protected void playAnimation(final EntityPlayer player, int radius) {
             player.getBukkitEntity().setMetadata("citizens.sitting",
                     new FixedMetadataValue(CitizensAPI.getPlugin(), true));
-            Bukkit.getScheduler().runTaskTimer(CitizensAPI.getPlugin(), new BukkitRunnable() {
+            new BukkitRunnable() {
                 @Override
                 public void run() {
-                    if (player.dead || !player.getBukkitEntity().getMetadata("citizens.sitting").get(0).asBoolean()) {
+                    if (player.dead || !player.valid ||
+                            !player.getBukkitEntity().getMetadata("citizens.sitting").get(0).asBoolean()) {
                         cancel();
                         return;
                     }
@@ -67,7 +68,7 @@ public enum PlayerAnimation {
                         player.mount(player);
                     }
                 }
-            }, 0, 1);
+            }.runTaskTimer(CitizensAPI.getPlugin(), 0, 1);
         }
     },
     SLEEP {


### PR DESCRIPTION
The task would fail to cancel properly, and sometimes fail to recognize
NPC removal.
In addition, gitignore maven and IntelliJ artifacts to give contributors
an easier time.
