### PR TITLE
Disable bat AI, fixes #137

### DIFF
--- a/src/main/java/net/citizensnpcs/npc/entity/BatController.java
+++ b/src/main/java/net/citizensnpcs/npc/entity/BatController.java
@@ -107,8 +107,11 @@ public class BatController extends MobEntityController {
 
         @Override
         public void E() {
-            super.E();
-            if (npc != null) {
+            if (npc == null) {
+                super.E();
+            }
+            else {
+                NMS.updateAI(this);
                 npc.update();
             }
         }


### PR DESCRIPTION
Bat AI wasn't overridden properly... now it is.

 For https://github.com/CitizensDev/Citizens2/issues/137
