### PR TITLE
Fix no knock back on player NPC's when hit

### DIFF
--- a/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
+++ b/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
@@ -1,6 +1,7 @@
 package net.citizensnpcs.npc.ai;
 
 import java.util.Iterator;
+import java.util.ListIterator;
 
 import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.api.ai.EntityTarget;
@@ -306,8 +307,8 @@ public class CitizensNavigator implements Navigator, Runnable {
     private static class DoorOpener implements PathCallback {
         @Override
         @SuppressWarnings("deprecation")
-        public void run(NPC npc, Block point, double radius) {
-            if (radius < 2) {
+        public void run(NPC npc, Block point, ListIterator<Block> path) {
+            if (npc.getStoredLocation().distance(point.getLocation()) < 2) {
                 boolean bottom = (point.getData() & 8) == 0;
                 Block set = bottom ? point : point.getRelative(BlockFace.DOWN);
                 set.setData((byte) ((set.getData() & 7) | 4));


### PR DESCRIPTION
Player NPC's do not get knocked back when hit.

The attacking players `EntityPlayer` object checks if the entity is a player and if so, sets the entities `velocityChanged` field to false, resets the velocity values and sends a packet to the client instead.

This fix sets the `velocityChanged` field to false to prevent the velocity from being reset, waits until after the check is done and sets the `velocityChanged` value back to `true`.