### PR TITLE
Restore unintentionally deleted API method

### DIFF
--- a/src/main/java/net/citizensnpcs/util/NMS.java
+++ b/src/main/java/net/citizensnpcs/util/NMS.java
@@ -553,6 +553,19 @@ public class NMS {
         ((CraftServer) Bukkit.getServer()).getHandle().players.remove(handle);
     }
 
+    public static void addOrRemoveFromPlayerList(org.bukkit.entity.Entity entity, boolean remove) {
+        if (entity == null)
+            return;
+        EntityHuman handle = (EntityHuman) getHandle(entity);
+        if (handle.world == null)
+            return;
+        if (remove) {
+            handle.world.players.remove(handle);
+        } else if (!handle.world.players.contains(handle)) {
+            handle.world.players.add(handle);
+        }
+    }
+
     @SuppressWarnings("rawtypes")
     public static void replaceTrackerEntry(Player player) {
         WorldServer server = (WorldServer) NMS.getHandle(player).getWorld();


### PR DESCRIPTION
Time to play a game of 'what could go wrong' as I can't compile atm but this is a high priority needed fix for Denizen to work correctly/run/compile :(