### PR TITLE
bug fix and optimizations in NPC skins

### DIFF
--- a/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -189,23 +189,11 @@ public class CitizensNPC extends AbstractNPC {
         boolean couldSpawn = !Util.isLoaded(at) ? false : mcEntity.world.addEntity(mcEntity, SpawnReason.CUSTOM);
 
         // send skin packets, if applicable, before other NMS packets are sent
-        SkinnableEntity skinnable = NMS.getSkinnable(getEntity());
-        if (skinnable != null) {
-            final double viewDistance = Settings.Setting.NPC_SKIN_VIEW_DISTANCE.asDouble();
-            //skinnable.getSkinTracker().updateNearbyViewers(viewDistance);
-            Bukkit.getScheduler().scheduleSyncDelayedTask(CitizensAPI.getPlugin(), new Runnable() {
-                @Override
-                public void run() {
-                    if (getEntity() == null || !getEntity().isValid())
-                        return;
-
-                    SkinnableEntity npc = NMS.getSkinnable(getEntity());
-                    if (npc == null)
-                        return;
-
-                    npc.getSkinTracker().updateNearbyViewers(viewDistance);
-                }
-            }, 20);
+        if (couldSpawn) {
+            SkinnableEntity skinnable = NMS.getSkinnable(getEntity());
+            if (skinnable != null) {
+                skinnable.getSkinTracker().onSpawnNPC();
+            }
         }
 
         mcEntity.setPositionRotation(at.getX(), at.getY(), at.getZ(), at.getYaw(), at.getPitch());


### PR DESCRIPTION
fixed client sometimes disconnects for: Internal Exception: io.netty.handler.codec.DecoderException: java.io.IOException: Packet 0/56 (ki) was larger than I expected, found 917 bytes extra whilst reading packet 56;
changes in Skin#setNPCTexture

Allow retrieving Skin instance by skin name instead of entity so it can be retrieved without a spawned entity instance. Changes in Skin and SkinPacketTracker.

remove redundant scheduled skin update tasks in CitizensNPC and EventListen; provide no benefit

reset current SkinUpdateTracker instance if exists instead of creating a new one for all players in EventListen#onCitizensReload

reset rotation count in EventListen when player teleports/changes world/etc