### PR TITLE
Add NPC_METADATA_MARKER before teleporting

### DIFF
--- a/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -196,6 +196,8 @@ public class CitizensNPC extends AbstractNPC {
 
         entityController.spawn(at, this);
 
+        getEntity().setMetadata(NPC_METADATA_MARKER, new FixedMetadataValue(CitizensAPI.getPlugin(), true));
+
         boolean couldSpawn = !Util.isLoaded(at) ? false : NMS.addEntityToWorld(getEntity(), SpawnReason.CUSTOM);
 
         // send skin packets, if applicable, before other NMS packets are sent
@@ -218,8 +220,6 @@ public class CitizensNPC extends AbstractNPC {
         }
 
         NMS.setHeadYaw(getEntity(), at.getYaw());
-
-        getEntity().setMetadata(NPC_METADATA_MARKER, new FixedMetadataValue(CitizensAPI.getPlugin(), true));
 
         // Set the spawned state
         getTrait(CurrentLocation.class).setLocation(at);


### PR DESCRIPTION
This solves an issue I have, namely that I cannot check if a "Player" is an NPC on a PlayerTeleportEvent when the NPC is spawning. Fixes https://bitbucket.org/Lolmewn/stats/issues/292/citizen-denizen-npc-issue