### PR TITLE
Fix NoSuchMethodError

### DIFF
--- a/v1_10_R1/pom.xml
+++ b/v1_10_R1/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<craftbukkit.version>1.10-R0.1-SNAPSHOT</craftbukkit.version> 
+		<craftbukkit.version>1.10.2-R0.1-SNAPSHOT</craftbukkit.version>
 	</properties>
 
 	<repositories> 

--- a/v1_11_R1/pom.xml
+++ b/v1_11_R1/pom.xml
@@ -11,7 +11,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<craftbukkit.version>1.11-R0.1-SNAPSHOT</craftbukkit.version> 
+		<craftbukkit.version>1.11.2-R0.1-SNAPSHOT</craftbukkit.version>
 	</properties>
 
 	<repositories> 

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -1137,7 +1137,7 @@ public class NMSImpl implements NMSBridge {
                 double d1 = entity.locY;
                 float f4 = entity instanceof EntityPolarBear ? 0.98F : 0.8F;
                 float f3 = 0.02F;
-                float f2 = EnchantmentManager.d(entity);
+                float f2 = EnchantmentManager.e(entity);
                 if (f2 > 3.0F) {
                     f2 = 3.0F;
                 }


### PR DESCRIPTION
Those 2 commits fix NoSuchMethodError (stack trace below) and update NMS version to 1.10 -> 1.10.2 and 1.11 -> 1.11.2

```
[20:20:20 WARN]: Entity threw exception at world:-117.11897153991481,76.0,-279.31206144784755
[20:20:20 WARN]: java.lang.NoSuchMethodError: net.minecraft.server.v1_11_R1.EnchantmentManager.a(Lnet/minecraft/server/v1_11_R1/EntityLiving;)I
[20:20:20 WARN]: 	at net.citizensnpcs.nms.v1_11_R1.util.NMSImpl.attack(NMSImpl.java:251)
[20:20:20 WARN]: 	at net.citizensnpcs.util.NMS.attack(NMS.java:49)
[20:20:20 WARN]: 	at net.citizensnpcs.npc.ai.MCTargetStrategy$1.handle(MCTargetStrategy.java:199)
[20:20:20 WARN]: 	at net.citizensnpcs.npc.ai.MCTargetStrategy.update(MCTargetStrategy.java:127)
[20:20:20 WARN]: 	at net.citizensnpcs.npc.ai.CitizensNavigator.run(CitizensNavigator.java:163)
[20:20:20 WARN]: 	at net.citizensnpcs.npc.CitizensNPC.update(CitizensNPC.java:274)
[20:20:20 WARN]: 	at net.citizensnpcs.nms.v1_11_R1.entity.SkeletonController$EntitySkeletonNPC.M(SkeletonController.java:170)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityInsentient.doTick(EntityInsentient.java:669)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityLiving.n(EntityLiving.java:2054)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityInsentient.n(EntityInsentient.java:502)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityMonster.n(EntityMonster.java:24)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntitySkeletonAbstract.n(EntitySkeletonAbstract.java:96)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityLiving.A_(EntityLiving.java:1914)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityInsentient.A_(EntityInsentient.java:245)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.EntityMonster.A_(EntityMonster.java:28)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.World.entityJoinedWorld(World.java:1743)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.World.h(World.java:1718)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.World.tickEntities(World.java:1535)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.WorldServer.tickEntities(WorldServer.java:620)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.MinecraftServer.D(MinecraftServer.java:885)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.DedicatedServer.D(DedicatedServer.java:403)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.MinecraftServer.C(MinecraftServer.java:749)
[20:20:20 WARN]: 	at net.minecraft.server.v1_11_R1.MinecraftServer.run(MinecraftServer.java:648)
[20:20:20 WARN]: 	at java.lang.Thread.run(Thread.java:745)
```