### PR TITLE
( Patch for #1455 ) reload saves rather than reconstructing

### DIFF
--- a/main/src/main/java/net/citizensnpcs/Citizens.java
+++ b/main/src/main/java/net/citizensnpcs/Citizens.java
@@ -355,7 +355,7 @@ public class Citizens extends JavaPlugin implements CitizensPlugin {
         Skin.clearCache();
         getServer().getPluginManager().callEvent(new CitizensPreReloadEvent());
 
-        saves = createStorage(getDataFolder());
+        saves.reloadFromSource();
         saves.loadInto(npcRegistry);
 
         getServer().getPluginManager().callEvent(new CitizensReloadEvent());


### PR DESCRIPTION
Creating a new data storage in the reload method effectively invalidates the data storage entirely. This patch calls the method I added in https://github.com/CitizensDev/CitizensAPI/pull/37 to reload the save data rather than creating a new object and pushing it to an effectively irrelevant field (where the NPCRegistry has no knowledge of the sudden object swap).