### PR TITLE
( Patch for #1453 ) proper wolf command output

### DIFF
--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -1971,7 +1971,7 @@ public class NPCCommands {
             min = 1,
             max = 1,
             requiresFlags = true,
-            flags = "sat",
+            flags = "sati",
             permission = "citizens.npc.wolf")
     @Requirements(selected = true, ownership = true, types = EntityType.WOLF)
     public void wolf(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
@@ -2002,9 +2002,7 @@ public class NPCCommands {
                 throw new CommandException(Messages.COLLAR_COLOUR_NOT_SUPPORTED, unparsed);
             trait.setCollarColor(color);
         }
-        if (args.hasFlag('i')) {
-            Messaging.sendTr(sender, Messages.WOLF_TRAIT_UPDATED, npc.getName(), args.hasFlag('a'), args.hasFlag('s'),
-                    args.hasFlag('t'), trait.getCollarColor().name());
-        }
+        Messaging.sendTr(sender, Messages.WOLF_TRAIT_UPDATED, npc.getName(), trait.isAngry(), trait.isSitting(),
+                trait.isTamed(), trait.getCollarColor().name());
     }
 }


### PR DESCRIPTION
"i" flag is left in as a way to get info output but not actually checked (as info output should also appear if changes are made)

FOR FURTHER CONSIDERATION: Should the collar logic support RGB input values at all? It doesn't actually allow dynamic RGB input, it just looks up the RGB value in a mapping of the 16 named colors.