### PR TITLE
( Patch for #1498 ) protect villager npcs from lightning

### DIFF
--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/VillagerController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/VillagerController.java
@@ -23,6 +23,7 @@ import net.minecraft.server.v1_10_R1.ItemStack;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.SoundEffect;
 import net.minecraft.server.v1_10_R1.World;
+import net.minecraft.server.v1_10_R1.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {
@@ -215,6 +216,13 @@ public class VillagerController extends MobEntityController {
                 return super.m_();
             } else {
                 return false;
+            }
+        }
+
+        @Override
+        public void onLightningStrike(EntityLightning entitylightning) {
+            if (npc == null) {
+                super.onLightningStrike(entitylightning);
             }
         }
 

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/VillagerController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/VillagerController.java
@@ -25,6 +25,7 @@ import net.minecraft.server.v1_11_R1.MerchantRecipe;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.SoundEffect;
 import net.minecraft.server.v1_11_R1.World;
+import net.minecraft.server.v1_11_R1.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {
@@ -221,6 +222,13 @@ public class VillagerController extends MobEntityController {
                 return super.m_();
             } else {
                 return false;
+            }
+        }
+
+        @Override
+        public void onLightningStrike(EntityLightning entitylightning) {
+            if (npc == null) {
+                super.onLightningStrike(entitylightning);
             }
         }
 

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/VillagerController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/VillagerController.java
@@ -26,6 +26,7 @@ import net.minecraft.server.v1_12_R1.MerchantRecipe;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.SoundEffect;
 import net.minecraft.server.v1_12_R1.World;
+import net.minecraft.server.v1_12_R1.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {
@@ -224,6 +225,13 @@ public class VillagerController extends MobEntityController {
                 return super.m_();
             } else {
                 return false;
+            }
+        }
+
+        @Override
+        public void onLightningStrike(EntityLightning entitylightning) {
+            if (npc == null) {
+                super.onLightningStrike(entitylightning);
             }
         }
 

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/VillagerController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/VillagerController.java
@@ -20,6 +20,7 @@ import net.minecraft.server.v1_8_R3.EntityHuman;
 import net.minecraft.server.v1_8_R3.EntityVillager;
 import net.minecraft.server.v1_8_R3.NBTTagCompound;
 import net.minecraft.server.v1_8_R3.World;
+import net.minecraft.server.v1_8_R3.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {
@@ -207,6 +208,13 @@ public class VillagerController extends MobEntityController {
                 return super.k_();
             } else {
                 return false;
+            }
+        }
+
+        @Override
+        public void onLightningStrike(EntityLightning entitylightning) {
+            if (npc == null) {
+                super.onLightningStrike(entitylightning);
             }
         }
 


### PR DESCRIPTION
When a villager is struck by lightning the villager that was struck gets removed and a new entity of type witch spawns in its place.

If this happens to an NPC villager the underlying entity controlled by the NPC gets removed and the new entity of type witch that spawns in its place is not controlled by an NPC anymore and behaves like a vanilla entity.

Preventing `void onLightningStrike(EntityLightning)` from executing does not prevent the lightning strike itself, it only prevents the effect(s) it has on an entity (such as a villager turning into a witch or a pig turning into a zombie pigman).