### PR TITLE
( Patch for #1509 ) support zombie villagers in the villager profession trait

### DIFF
--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -1223,7 +1223,7 @@ public class NPCCommands {
             min = 2,
             max = 2,
             permission = "citizens.npc.profession")
-    @Requirements(selected = true, ownership = true, types = { EntityType.VILLAGER })
+    @Requirements(selected = true, ownership = true, types = { EntityType.VILLAGER, EntityType.ZOMBIE_VILLAGER })
     public void profession(CommandContext args, CommandSender sender, NPC npc) throws CommandException {
         String profession = args.getString(1);
         Profession parsed = Util.matchEnum(Profession.values(), profession.toUpperCase());

--- a/main/src/main/java/net/citizensnpcs/trait/VillagerProfession.java
+++ b/main/src/main/java/net/citizensnpcs/trait/VillagerProfession.java
@@ -7,6 +7,7 @@ import net.citizensnpcs.api.exception.NPCLoadException;
 import net.citizensnpcs.api.trait.Trait;
 import net.citizensnpcs.api.trait.TraitName;
 import net.citizensnpcs.api.util.DataKey;
+import org.bukkit.entity.ZombieVillager;
 
 @TraitName("profession")
 public class VillagerProfession extends Trait {
@@ -32,6 +33,8 @@ public class VillagerProfession extends Trait {
     public void onSpawn() {
         if (npc.getEntity() instanceof Villager) {
             ((Villager) npc.getEntity()).setProfession(profession);
+        } else if (npc.getEntity() instanceof ZombieVillager) {
+            ((ZombieVillager) npc.getEntity()).setVillagerProfession(profession);
         }
     }
 
@@ -47,6 +50,8 @@ public class VillagerProfession extends Trait {
         this.profession = profession;
         if (npc.getEntity() instanceof Villager) {
             ((Villager) npc.getEntity()).setProfession(profession);
+        } else if (npc.getEntity() instanceof ZombieVillager) {
+            ((ZombieVillager) npc.getEntity()).setVillagerProfession(profession);
         }
     }
 


### PR DESCRIPTION
Because the Zombie Villager does not inherit from the Villager entity, and the Villager profession trait in Citizens2 only checks the Villager interface and only uses `Villager#setProfession(Profession)` to set the profession of a Villager NPC it does not support the Zombie Villager entity.

I added support for the Zombie Villager entity by allowing the `/npc profession|prof [profession]`  command to be used on the Zombie Villager type and added separate checks in the profession trait for villagers to support the Zombie Villager entity.