### PR TITLE
Fix for client NPE issue - don't missend player spawn packets

### DIFF
--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/EntityHumanNPC.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/EntityHumanNPC.java
@@ -74,6 +74,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
     private final Location packetLocationCache = new Location(null, 0, 0, 0);
     private final SkinPacketTracker skinTracker;
     private int updateCounter = 0;
+    private boolean isTracked = false;
 
     public EntityHumanNPC(MinecraftServer minecraftServer, WorldServer world, GameProfile gameProfile,
             PlayerInteractManager playerInteractManager, NPC npc) {
@@ -87,6 +88,18 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         } else {
             skinTracker = null;
         }
+    }
+
+    public void setTracked() {
+        isTracked = true;
+    }
+
+    @Override
+    public boolean a(EntityPlayer entityplayer) {
+        if (npc != null && !isTracked) {
+            return false;
+        }
+        return super.a(entityplayer);
     }
 
     @Override

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -37,8 +37,8 @@ public class HumanController extends AbstractEntityController {
 
         String name = coloredName, prefix = null, suffix = null;
         if (coloredName.length() > 16) {
-            prefix = coloredName.substring(0, 16);
             if (coloredName.length() >= 30) {
+                prefix = coloredName.substring(0, 16);
                 int len = 30;
                 name = coloredName.substring(16, 30);
                 if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
@@ -54,7 +54,8 @@ public class HumanController extends AbstractEntityController {
                 }
                 suffix = coloredName.substring(len);
             } else {
-                name = coloredName.substring(16);
+                prefix = coloredName.substring(0, coloredName.length() - 16);
+                name = coloredName.substring(prefix.length());
                 if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
                     name = ChatColor.RESET + name;
                 }

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -756,6 +756,9 @@ public class NMSImpl implements NMSBridge {
                 e.printStackTrace();
             }
         }
+        if (getHandle(player) instanceof EntityHumanNPC) {
+            ((EntityHumanNPC) getHandle(player)).setTracked();
+        }
     }
 
     @Override

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/EntityHumanNPC.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/EntityHumanNPC.java
@@ -76,6 +76,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
     private final Location packetLocationCache = new Location(null, 0, 0, 0);
     private final SkinPacketTracker skinTracker;
     private int updateCounter = 0;
+    private boolean isTracked = false;
 
     public EntityHumanNPC(MinecraftServer minecraftServer, WorldServer world, GameProfile gameProfile,
             PlayerInteractManager playerInteractManager, NPC npc) {
@@ -89,6 +90,18 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         } else {
             skinTracker = null;
         }
+    }
+
+    public void setTracked() {
+        isTracked = true;
+    }
+
+    @Override
+    public boolean a(EntityPlayer entityplayer) {
+        if (npc != null && !isTracked) {
+            return false;
+        }
+        return super.a(entityplayer);
     }
 
     @Override

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -37,8 +37,8 @@ public class HumanController extends AbstractEntityController {
 
         String name = coloredName, prefix = null, suffix = null;
         if (coloredName.length() > 16) {
-            prefix = coloredName.substring(0, 16);
             if (coloredName.length() >= 30) {
+                prefix = coloredName.substring(0, 16);
                 int len = 30;
                 name = coloredName.substring(16, 30);
                 if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
@@ -54,7 +54,8 @@ public class HumanController extends AbstractEntityController {
                 }
                 suffix = coloredName.substring(len);
             } else {
-                name = coloredName.substring(16);
+                prefix = coloredName.substring(0, coloredName.length() - 16);
+                name = coloredName.substring(prefix.length());
                 if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
                     name = ChatColor.RESET + name;
                 }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -814,6 +814,9 @@ public class NMSImpl implements NMSBridge {
                 e.printStackTrace();
             }
         }
+        if (getHandle(player) instanceof EntityHumanNPC) {
+            ((EntityHumanNPC) getHandle(player)).setTracked();
+        }
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/EntityHumanNPC.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/EntityHumanNPC.java
@@ -79,6 +79,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
     private final Location packetLocationCache = new Location(null, 0, 0, 0);
     private final SkinPacketTracker skinTracker;
     private int updateCounter = 0;
+    private boolean isTracked = false;
 
     public EntityHumanNPC(MinecraftServer minecraftServer, WorldServer world, GameProfile gameProfile,
             PlayerInteractManager playerInteractManager, NPC npc) {
@@ -92,6 +93,18 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         } else {
             skinTracker = null;
         }
+    }
+
+    public void setTracked() {
+        isTracked = true;
+    }
+
+    @Override
+    public boolean a(EntityPlayer entityplayer) {
+        if (npc != null && !isTracked) {
+            return false;
+        }
+        return super.a(entityplayer);
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -37,8 +37,8 @@ public class HumanController extends AbstractEntityController {
 
         String name = coloredName, prefix = null, suffix = null;
         if (coloredName.length() > 16) {
-            prefix = coloredName.substring(0, 16);
             if (coloredName.length() >= 30) {
+                prefix = coloredName.substring(0, 16);
                 int len = 30;
                 name = coloredName.substring(16, 30);
                 if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
@@ -54,7 +54,8 @@ public class HumanController extends AbstractEntityController {
                 }
                 suffix = coloredName.substring(len);
             } else {
-                name = coloredName.substring(16);
+                prefix = coloredName.substring(0, coloredName.length() - 16);
+                name = coloredName.substring(prefix.length());
                 if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
                     name = ChatColor.RESET + name;
                 }

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -821,6 +821,9 @@ public class NMSImpl implements NMSBridge {
                 e.printStackTrace();
             }
         }
+        if (getHandle(player) instanceof EntityHumanNPC) {
+            ((EntityHumanNPC) getHandle(player)).setTracked();
+        }
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/EntityHumanNPC.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/EntityHumanNPC.java
@@ -68,6 +68,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
     private final Location packetLocationCache = new Location(null, 0, 0, 0);
     private final SkinPacketTracker skinTracker;
     private int updateCounter = 0;
+    private boolean isTracked = false;
 
     public EntityHumanNPC(MinecraftServer minecraftServer, WorldServer world, GameProfile gameProfile,
             PlayerInteractManager playerInteractManager, NPC npc) {
@@ -81,6 +82,18 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         } else {
             skinTracker = null;
         }
+    }
+
+    public void setTracked() {
+        isTracked = true;
+    }
+
+    @Override
+    public boolean a(EntityPlayer entityplayer) {
+        if (npc != null && !isTracked) {
+            return false;
+        }
+        return super.a(entityplayer);
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -37,8 +37,8 @@ public class HumanController extends AbstractEntityController {
 
         String name = coloredName, prefix = null, suffix = null;
         if (coloredName.length() > 16) {
-            prefix = coloredName.substring(0, 16);
             if (coloredName.length() >= 30) {
+                prefix = coloredName.substring(0, 16);
                 int len = 30;
                 name = coloredName.substring(16, 30);
                 if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
@@ -54,7 +54,8 @@ public class HumanController extends AbstractEntityController {
                 }
                 suffix = coloredName.substring(len);
             } else {
-                name = coloredName.substring(16);
+                prefix = coloredName.substring(0, coloredName.length() - 16);
+                name = coloredName.substring(prefix.length());
                 if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
                     name = ChatColor.RESET + name;
                 }

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
@@ -711,6 +711,9 @@ public class NMSImpl implements NMSBridge {
                 e.printStackTrace();
             }
         }
+        if (getHandle(player) instanceof EntityHumanNPC) {
+            ((EntityHumanNPC) getHandle(player)).setTracked();
+        }
     }
 
     @Override


### PR DESCRIPTION
Player spawn packets were improperly sent by the Minecraft internals in early NPC spawn sequence, when they are not valid to be sent yet. This patch blocks their sending until the tracker system is pushed onto the NPC. Tested and functional.