### PR TITLE
Fixed the dependencies on the JAR to include 1.13

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -67,6 +67,13 @@
             <version>${project.version}</version>
             <type>jar</type>
             <scope>compile</scope>
-        </dependency> 
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>citizens-v1_13_R1</artifactId>
+            <version>${project.version}</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
This includes the 1.13 module into the outputed JAR so that it can properly load on Spigot 1.13-pre7 servers. The JAR will not properly load on 1.13-pre7 without this change.