### PR TITLE
Fix npc path block updates

### DIFF
--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -471,7 +471,7 @@ public class NMSImpl implements NMSBridge {
 
             @Override
             public void stop() {
-                if (navigation.k() != null) {
+                if (params.debug() && navigation.k() != null) {
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         for (int i = 0; i < navigation.k().d(); i++) {
                             PathPoint pp = navigation.k().a(i);

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -474,7 +474,7 @@ public class NMSImpl implements NMSBridge {
 
             @Override
             public void stop() {
-                if (navigation.l() != null) {
+                if (params.debug() && navigation.l() != null) {
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         for (int i = 0; i < navigation.l().d(); i++) {
                             PathPoint pp = navigation.l().a(i);

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.World;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
@@ -492,7 +493,7 @@ public class NMSImpl implements NMSBridge {
                             PathPoint pp = navigation.m().a(i);
                             org.bukkit.block.Block block = new Vector(pp.a, pp.b, pp.c).toLocation(player.getWorld())
                                     .getBlock();
-                            player.sendBlockChange(block.getLocation(), block.getType(), block.getData());
+                            player.sendBlockChange(block.getLocation(), block.getBlockData());
                         }
                     }
                 }
@@ -519,11 +520,11 @@ public class NMSImpl implements NMSBridge {
                     lastSpeed = params.speed();
                 }
                 if (params.debug() && !NMSImpl.isNavigationFinished(navigation)) {
+                    BlockData data = Material.DANDELION.createBlockData();
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         for (int i = 0; i < navigation.m().d(); i++) {
                             PathPoint pp = navigation.m().a(i);
-                            player.sendBlockChange(new Vector(pp.a, pp.b, pp.c).toLocation(player.getWorld()),
-                                    Material.SUNFLOWER, (byte) 0);
+                            player.sendBlockChange(new Vector(pp.a, pp.b, pp.c).toLocation(player.getWorld()), data);
                         }
                     }
                 }

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -487,7 +487,7 @@ public class NMSImpl implements NMSBridge {
 
             @Override
             public void stop() {
-                if (navigation.m() != null) {
+                if (params.debug() && navigation.m() != null) {
                     for (Player player : Bukkit.getOnlinePlayers()) {
                         for (int i = 0; i < navigation.m().d(); i++) {
                             PathPoint pp = navigation.m().a(i);


### PR DESCRIPTION
fixes https://github.com/CitizensDev/Citizens2/issues/1605

a combination of `use-new-finder: true` and `debug-pathfinding: true` also has the issue, however these are controlled in CitizensAPI:
https://github.com/CitizensDev/CitizensAPI/blob/dbc420949eb9c2ae417d03c0eca5b47b6874ed1b/src/main/java/net/citizensnpcs/api/astar/pathfinder/Path.java#L57
https://github.com/CitizensDev/CitizensAPI/blob/dbc420949eb9c2ae417d03c0eca5b47b6874ed1b/src/main/java/net/citizensnpcs/api/astar/pathfinder/Path.java#L66
the issue isn't present if `debug-pathfinding` is turned off for either pathfinding algorithm, so this probably isn't a priority but still good to fix.

and this should use `DANDELION` (1.13's yellow_flower):
https://github.com/CitizensDev/CitizensAPI/blob/dbc420949eb9c2ae417d03c0eca5b47b6874ed1b/src/main/java/net/citizensnpcs/api/astar/pathfinder/Path.java#L149