### PR TITLE
Fix spawn chunk NPC loading issues, fixes #1332

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -221,8 +221,6 @@ public class CitizensNPC extends AbstractNPC {
             }
         }
 
-        getEntity().teleport(at);
-
         if (!couldSpawn) {
             Messaging.debug("Retrying spawn of", getId(), "later due to chunk being unloaded.",
                     Util.isLoaded(at) ? "Util.isLoaded true" : "Util.isLoaded false");
@@ -231,6 +229,8 @@ public class CitizensNPC extends AbstractNPC {
             Bukkit.getPluginManager().callEvent(new NPCNeedsRespawnEvent(this, at));
             return false;
         }
+
+        getEntity().teleport(at);
 
         NMS.setHeadYaw(getEntity(), at.getYaw());
 


### PR DESCRIPTION
Some misplaced code unintentionally caused chunks to load in the middle of the startup sequence (after NPCs refused to spawn in the chunk, but before the server was fully started), meaning any chunk that normally loads within a few seconds of startup would be loaded already at that time, meaning a chunk load event never fires, and thus any NPCs at that location simply don't spawn in until the chunk is allowed to naturally unload and is later loaded again.