### PR TITLE
Patch 1.8 pathfinding issue

### DIFF
--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/PlayerPathfinderNormal.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/PlayerPathfinderNormal.java
@@ -94,6 +94,9 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
                         return null;
                     }
                 }
+                else {
+                    break;
+                }
             }
             if (n == -2) {
                 return null;


### PR DESCRIPTION
Some users have reported 1.8 server freezing here - looks like the original NMS method was miscopied, this patch should bring it properly in-line.