### PR TITLE
Improve handling of NPC names, fixes #1640

### DIFF
--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -1,8 +1,10 @@
 package net.citizensnpcs.util;
 
 import java.util.Random;
+import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Entity;
@@ -34,6 +36,57 @@ public class Util {
         if (NPCCollisionEvent.getHandlerList().getRegisteredListeners().length > 0) {
             Bukkit.getPluginManager().callEvent(new NPCCollisionEvent(npc, entity));
         }
+    }
+
+
+    private static Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
+
+    public static String[] splitPlayerName(String coloredName) {
+        String name = coloredName, prefix = null, suffix = null;
+        if (coloredName.length() > 16) {
+            if (coloredName.length() >= 30) {
+                prefix = coloredName.substring(0, 16);
+                int len = 30;
+                name = coloredName.substring(16, 30);
+                if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
+                    if (coloredName.length() >= 32) {
+                        len = 32;
+                        name = coloredName.substring(16, 32);
+                    } else if (coloredName.length() == 31) {
+                        len = 31;
+                        name = coloredName.substring(16, 31);
+                    }
+                } else {
+                    String prefixColors = ChatColor.getLastColors(prefix);
+                    if (prefixColors.isEmpty()) {
+                        prefixColors = ChatColor.RESET.toString();
+                    }
+                    else if (prefixColors.length() > 2) {
+                        prefixColors = prefixColors.substring(prefixColors.length() - 2);
+                    }
+                    name = prefixColors + name;
+                }
+                suffix = coloredName.substring(len);
+            } else {
+                prefix = coloredName.substring(0, coloredName.length() - 16);
+                name = coloredName.substring(prefix.length());
+                if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
+                    String prefixColors = ChatColor.getLastColors(prefix);
+                    if (prefixColors.isEmpty()) {
+                        prefixColors = ChatColor.RESET.toString();
+                    }
+                    else if (prefixColors.length() > 2) {
+                        prefixColors = prefixColors.substring(prefixColors.length() - 2);
+                    }
+                    name = prefixColors + name;
+                }
+                if (name.length() > 16) {
+                    suffix = name.substring(16);
+                    name = name.substring(0, 16);
+                }
+            }
+        }
+        return new String[] { name, prefix, suffix };
     }
 
     public static NPCPushEvent callPushEvent(NPC npc, Vector vector) {

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -70,6 +70,10 @@ public class Util {
             } else {
                 prefix = coloredName.substring(0, coloredName.length() - 16);
                 name = coloredName.substring(prefix.length());
+                if (prefix.endsWith(String.valueOf(ChatColor.COLOR_CHAR))) {
+                    prefix = prefix.substring(0, prefix.length() - 1);
+                    name = ChatColor.COLOR_CHAR + name;
+                }
                 if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
                     String prefixColors = ChatColor.getLastColors(prefix);
                     if (prefixColors.isEmpty()) {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -1,10 +1,9 @@
 package net.citizensnpcs.nms.v1_10_R1.entity;
 
 import java.util.UUID;
-import java.util.regex.Pattern;
 
+import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
 import org.bukkit.entity.Entity;
@@ -35,38 +34,10 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = Colorizer.parseColors(npc.getFullName());
 
-        String name = coloredName, prefix = null, suffix = null;
-        if (coloredName.length() > 16) {
-            if (coloredName.length() >= 30) {
-                prefix = coloredName.substring(0, 16);
-                int len = 30;
-                name = coloredName.substring(16, 30);
-                if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    if (coloredName.length() >= 32) {
-                        len = 32;
-                        name = coloredName.substring(16, 32);
-                    } else if (coloredName.length() == 31) {
-                        len = 31;
-                        name = coloredName.substring(16, 31);
-                    }
-                } else {
-                    name = ChatColor.RESET + name;
-                }
-                suffix = coloredName.substring(len);
-            } else {
-                prefix = coloredName.substring(0, coloredName.length() - 16);
-                name = coloredName.substring(prefix.length());
-                if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    name = ChatColor.RESET + name;
-                }
-                if (name.length() > 16) {
-                    suffix = name.substring(16);
-                    name = name.substring(0, 16);
-                }
-            }
-        }
+        String[] nameSplit = Util.splitPlayerName(coloredName);
+        String name = nameSplit[0];
 
-        final String prefixCapture = prefix, suffixCapture = suffix;
+        final String prefixCapture = nameSplit[1], suffixCapture = nameSplit[2];
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -148,6 +119,4 @@ public class HumanController extends AbstractEntityController {
         }
         super.remove();
     }
-
-    private static Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
 }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -1,10 +1,9 @@
 package net.citizensnpcs.nms.v1_11_R1.entity;
 
 import java.util.UUID;
-import java.util.regex.Pattern;
 
+import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
 import org.bukkit.entity.Entity;
@@ -35,38 +34,10 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = Colorizer.parseColors(npc.getFullName());
 
-        String name = coloredName, prefix = null, suffix = null;
-        if (coloredName.length() > 16) {
-            if (coloredName.length() >= 30) {
-                prefix = coloredName.substring(0, 16);
-                int len = 30;
-                name = coloredName.substring(16, 30);
-                if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    if (coloredName.length() >= 32) {
-                        len = 32;
-                        name = coloredName.substring(16, 32);
-                    } else if (coloredName.length() == 31) {
-                        len = 31;
-                        name = coloredName.substring(16, 31);
-                    }
-                } else {
-                    name = ChatColor.RESET + name;
-                }
-                suffix = coloredName.substring(len);
-            } else {
-                prefix = coloredName.substring(0, coloredName.length() - 16);
-                name = coloredName.substring(prefix.length());
-                if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    name = ChatColor.RESET + name;
-                }
-                if (name.length() > 16) {
-                    suffix = name.substring(16);
-                    name = name.substring(0, 16);
-                }
-            }
-        }
+        String[] nameSplit = Util.splitPlayerName(coloredName);
+        String name = nameSplit[0];
 
-        final String prefixCapture = prefix, suffixCapture = suffix;
+        final String prefixCapture = nameSplit[1], suffixCapture = nameSplit[2];
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -148,6 +119,4 @@ public class HumanController extends AbstractEntityController {
         }
         super.remove();
     }
-
-    private static Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
 }

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -1,10 +1,9 @@
 package net.citizensnpcs.nms.v1_12_R1.entity;
 
 import java.util.UUID;
-import java.util.regex.Pattern;
 
+import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
 import org.bukkit.entity.Entity;
@@ -35,38 +34,10 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = Colorizer.parseColors(npc.getFullName());
 
-        String name = coloredName, prefix = null, suffix = null;
-        if (coloredName.length() > 16) {
-            if (coloredName.length() >= 30) {
-                prefix = coloredName.substring(0, 16);
-                int len = 30;
-                name = coloredName.substring(16, 30);
-                if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    if (coloredName.length() >= 32) {
-                        len = 32;
-                        name = coloredName.substring(16, 32);
-                    } else if (coloredName.length() == 31) {
-                        len = 31;
-                        name = coloredName.substring(16, 31);
-                    }
-                } else {
-                    name = ChatColor.RESET + name;
-                }
-                suffix = coloredName.substring(len);
-            } else {
-                prefix = coloredName.substring(0, coloredName.length() - 16);
-                name = coloredName.substring(prefix.length());
-                if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    name = ChatColor.RESET + name;
-                }
-                if (name.length() > 16) {
-                    suffix = name.substring(16);
-                    name = name.substring(0, 16);
-                }
-            }
-        }
+        String[] nameSplit = Util.splitPlayerName(coloredName);
+        String name = nameSplit[0];
 
-        final String prefixCapture = prefix, suffixCapture = suffix;
+        final String prefixCapture = nameSplit[1], suffixCapture = nameSplit[2];
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -148,6 +119,4 @@ public class HumanController extends AbstractEntityController {
         }
         super.remove();
     }
-
-    private static Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
 }

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -1,10 +1,9 @@
 package net.citizensnpcs.nms.v1_13_R2.entity;
 
 import java.util.UUID;
-import java.util.regex.Pattern;
 
+import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
 import org.bukkit.entity.Entity;
@@ -35,38 +34,10 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = Colorizer.parseColors(npc.getFullName());
 
-        String name = coloredName, prefix = null, suffix = null;
-        if (coloredName.length() > 16) {
-            if (coloredName.length() >= 30) {
-                prefix = coloredName.substring(0, 16);
-                int len = 30;
-                name = coloredName.substring(16, 30);
-                if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    if (coloredName.length() >= 32) {
-                        len = 32;
-                        name = coloredName.substring(16, 32);
-                    } else if (coloredName.length() == 31) {
-                        len = 31;
-                        name = coloredName.substring(16, 31);
-                    }
-                } else {
-                    name = ChatColor.RESET + name;
-                }
-                suffix = coloredName.substring(len);
-            } else {
-                prefix = coloredName.substring(0, coloredName.length() - 16);
-                name = coloredName.substring(prefix.length());
-                if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    name = ChatColor.RESET + name;
-                }
-                if (name.length() > 16) {
-                    suffix = name.substring(16);
-                    name = name.substring(0, 16);
-                }
-            }
-        }
+        String[] nameSplit = Util.splitPlayerName(coloredName);
+        String name = nameSplit[0];
 
-        final String prefixCapture = prefix, suffixCapture = suffix;
+        final String prefixCapture = nameSplit[1], suffixCapture = nameSplit[2];
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -148,6 +119,4 @@ public class HumanController extends AbstractEntityController {
         }
         super.remove();
     }
-
-    private static Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
 }

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -1,10 +1,9 @@
 package net.citizensnpcs.nms.v1_8_R3.entity;
 
 import java.util.UUID;
-import java.util.regex.Pattern;
 
+import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.entity.Entity;
@@ -35,38 +34,10 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = Colorizer.parseColors(npc.getFullName());
 
-        String name = coloredName, prefix = null, suffix = null;
-        if (coloredName.length() > 16) {
-            if (coloredName.length() >= 30) {
-                prefix = coloredName.substring(0, 16);
-                int len = 30;
-                name = coloredName.substring(16, 30);
-                if (NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    if (coloredName.length() >= 32) {
-                        len = 32;
-                        name = coloredName.substring(16, 32);
-                    } else if (coloredName.length() == 31) {
-                        len = 31;
-                        name = coloredName.substring(16, 31);
-                    }
-                } else {
-                    name = ChatColor.RESET + name;
-                }
-                suffix = coloredName.substring(len);
-            } else {
-                prefix = coloredName.substring(0, coloredName.length() - 16);
-                name = coloredName.substring(prefix.length());
-                if (!NON_ALPHABET_MATCHER.matcher(name).matches()) {
-                    name = ChatColor.RESET + name;
-                }
-                if (name.length() > 16) {
-                    suffix = name.substring(16);
-                    name = name.substring(0, 16);
-                }
-            }
-        }
+        String[] nameSplit = Util.splitPlayerName(coloredName);
+        String name = nameSplit[0];
 
-        final String prefixCapture = prefix, suffixCapture = suffix;
+        final String prefixCapture = nameSplit[1], suffixCapture = nameSplit[2];
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -148,6 +119,4 @@ public class HumanController extends AbstractEntityController {
         }
         super.remove();
     }
-
-    private static Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
 }


### PR DESCRIPTION
Moves the logic to a Util method (instead of duplicated in each module), and adds the "prefixColors" portions (replacing just a static 'RESET' code).
If colors and effects are combined, using only the most recent effect is sufficient (eg reapplying bold) as that should produce effectively no change while still having a color code stuck into the name as is needed to break NPCs looking like real players internally.