### PR TITLE
DisplayName trait

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/CitizensTraitFactory.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensTraitFactory.java
@@ -24,6 +24,7 @@ import net.citizensnpcs.trait.Anchors;
 import net.citizensnpcs.trait.ArmorStandTrait;
 import net.citizensnpcs.trait.Controllable;
 import net.citizensnpcs.trait.CurrentLocation;
+import net.citizensnpcs.trait.DisplayName;
 import net.citizensnpcs.trait.FollowTrait;
 import net.citizensnpcs.trait.GameModeTrait;
 import net.citizensnpcs.trait.Gravity;
@@ -56,6 +57,7 @@ public class CitizensTraitFactory implements TraitFactory {
         registerTrait(TraitInfo.create(Anchors.class));
         registerTrait(TraitInfo.create(Controllable.class));
         registerTrait(TraitInfo.create(CurrentLocation.class));
+        registerTrait(TraitInfo.create(DisplayName.class));
         registerTrait(TraitInfo.create(Equipment.class));
         registerTrait(TraitInfo.create(FollowTrait.class));
         registerTrait(TraitInfo.create(GameModeTrait.class));

--- a/main/src/main/java/net/citizensnpcs/trait/DisplayName.java
+++ b/main/src/main/java/net/citizensnpcs/trait/DisplayName.java
@@ -1,0 +1,27 @@
+package net.citizensnpcs.trait;
+
+import net.citizensnpcs.api.command.CommandConfigurable;
+import net.citizensnpcs.api.command.CommandContext;
+import net.citizensnpcs.api.persistence.Persist;
+import net.citizensnpcs.api.trait.Trait;
+import net.citizensnpcs.api.trait.TraitName;
+
+@TraitName("displayname")
+public class DisplayName extends Trait implements CommandConfigurable{
+
+	@Persist public String name;
+	
+	public DisplayName(){
+		super("displayname");
+	}
+
+	public void configure(CommandContext args){
+		name = args.getJoinedStrings(1);
+	}
+	
+	public String getDisplayName(){
+		if (name == null) return npc.getName();
+		return name;
+	}
+
+}


### PR DESCRIPTION
This trait will be useful to external plugins, it allows NPCs to have different names than the one who is showed above the head.
For instance, I have a NPC named "Fisherman [Right Click]" and I want that others plugins can get "Fisher" directly from Citizens instead of passing through other plugins, to show in dialogs or quests.