### PR TITLE
Fix NPE

### DIFF
--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -937,7 +937,7 @@ public class NPCCommands {
             if (args.argsLength() != 3) {
                 throw new CommandException();
             }
-            npc.data().remove(args.getString(3));
+            npc.data().remove(args.getString(2));
             Messaging.sendTr(sender, Messages.METADATA_UNSET, args.getString(2));
         }
     }


### PR DESCRIPTION
Fixed the following error produced upon executing /npe metadata remove

`
[14:35:41 WARN]: java.lang.ArrayIndexOutOfBoundsException: 4
[14:35:41 WARN]: at net.citizensnpcs.api.command.CommandContext.getString(CommandContext.java:241)
[14:35:41 WARN]: at net.citizensnpcs.commands.NPCCommands.metadata(NPCCommands.java:940)
[14:35:41 WARN]: at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[14:35:41 WARN]: at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[14:35:41 WARN]: at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[14:35:41 WARN]: at java.lang.reflect.Method.invoke(Method.java:498)
[14:35:41 WARN]: at net.citizensnpcs.api.command.CommandManager.executeMethod(CommandManager.java:159)
[14:35:41 WARN]: at net.citizensnpcs.api.command.CommandManager.execute(CommandManager.java:91)
[14:35:41 WARN]: at net.citizensnpcs.api.command.CommandManager.executeSafe(CommandManager.java:187)
[14:35:41 WARN]: at net.citizensnpcs.Citizens.onCommand(Citizens.java:263)
[14:35:41 WARN]: at org.bukkit.command.PluginCommand.execute(PluginCommand.java:44)
[14:35:41 WARN]: at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:151)
[14:35:41 WARN]: at org.bukkit.craftbukkit.v1_12_R1.CraftServer.dispatchCommand(CraftServer.java:685)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.PlayerConnection.handleCommand(PlayerConnection.java:1473)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.PlayerConnection.a(PlayerConnection.java:1278)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.PacketPlayInChat.a(PacketPlayInChat.java:45)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.PacketPlayInChat.a(PacketPlayInChat.java:5)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.PlayerConnectionUtils.lambda$ensureMainThread$0(PlayerConnectionUtils.java:14)
[14:35:41 WARN]: at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[14:35:41 WARN]: at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.SystemUtils.a(SourceFile:46)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.MinecraftServer.D(MinecraftServer.java:849)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.DedicatedServer.D(DedicatedServer.java:423)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.MinecraftServer.C(MinecraftServer.java:773)
[14:35:41 WARN]: at net.minecraft.server.v1_12_R1.MinecraftServer.run(MinecraftServer.java:665)
[14:35:41 WARN]: at java.lang.Thread.run(Thread.java:748)`