### PR TITLE
Add a getter for Powered#powered

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/Powered.java
+++ b/main/src/main/java/net/citizensnpcs/trait/Powered.java
@@ -19,6 +19,10 @@ public class Powered extends Trait implements Toggleable {
     public Powered() {
         super("powered");
     }
+    
+    public boolean getPowered() {
+        return powered;
+    }
 
     @Override
     public void onSpawn() {


### PR DESCRIPTION
Currently, to check whether an NPC was powered, you had to get the entity and check via that. This change adds a getter to the trait directly to make the process easier, as the entity does not need to be accessed.