### PR TITLE
Fix broken Nectar message

### DIFF
--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/trait/Commands.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/trait/Commands.java
@@ -76,7 +76,7 @@ public class Commands {
         }
         if (args.hasFlag('n')) {
             trait.setNectar(!trait.hasNectar());
-            output += ' ' + (trait.hasStung() ? Messaging.tr(Messages.BEE_HAS_NECTAR, npc.getName())
+            output += ' ' + (trait.hasNectar() ? Messaging.tr(Messages.BEE_HAS_NECTAR, npc.getName())
                     : Messaging.tr(Messages.BEE_NO_NECTAR, npc.getName()));
         }
         if (!output.isEmpty()) {


### PR DESCRIPTION
The message/response displayed when running `/npc bee -n` was not based on if the bee had nectar/pollen or not, but instead if the bee was stung or not, meaning that it would always display `<name> has no nectar` when the bee wasn't stung and `<name> has nectar` when it was.

The PR corrects this by checking for `hasNectar()` instead of `hasStung()` when providing the message.