### PR TITLE
Implement packet-based scoreboard team enforcement

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -482,14 +482,14 @@ public class EventListen implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         skinUpdateTracker.updatePlayer(event.getPlayer(), 6 * 20, true);
 
-        for (NPC npc : getAllNPCs()) {
-            String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
-            Team team = null;
-            if (!(npc.getEntity() instanceof Player) || teamName.length() == 0
-                    || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
-                return;
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            for (NPC npc : getAllNPCs()) {
+                String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
+                Team team = null;
+                if (!(npc.getEntity() instanceof Player) || teamName.length() == 0
+                        || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
+                    return;
 
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 NMS.sendTeamPacket(event.getPlayer(), team);
             }
         }

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -484,11 +484,13 @@ public class EventListen implements Listener {
 
         if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
             for (NPC npc : getAllNPCs()) {
+                if (!(npc.getEntity() instanceof Player)) {
+                    continue;
+                }
                 String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
                 Team team = null;
-                if (!(npc.getEntity() instanceof Player) || teamName.length() == 0
-                        || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
-                    return;
+                if (teamName.length() == 0 || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
+                    continue;
 
                 NMS.sendTeamPacket(event.getPlayer(), team);
             }

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -481,6 +481,18 @@ public class EventListen implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerJoin(PlayerJoinEvent event) {
         skinUpdateTracker.updatePlayer(event.getPlayer(), 6 * 20, true);
+
+        for (NPC npc : getAllNPCs()) {
+            String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
+            Team team = null;
+            if (!(npc.getEntity() instanceof Player) || teamName.length() == 0
+                    || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
+                return;
+
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                NMS.sendTeamPacket(event.getPlayer(), team);
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
@@ -4,13 +4,18 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.scoreboard.Team.Option;
 import org.bukkit.scoreboard.Team.OptionStatus;
 
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.api.persistence.Persist;
+import net.citizensnpcs.Settings;
 import net.citizensnpcs.api.trait.Trait;
 import net.citizensnpcs.api.trait.TraitName;
 import net.citizensnpcs.util.NMS;
@@ -89,6 +94,22 @@ public class ScoreboardTrait extends Trait {
                     previousGlowingColor = color;
                 }
             }
+        }
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            NMS.sendTeamPacket(player, team);
+        }
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
+        Team team = null;
+        if (!(npc.getEntity() instanceof Player) || teamName.length() == 0
+                || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
+            return;
+
+        if (Settings.Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            NMS.sendTeamPacket(event.getPlayer(), team);
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
@@ -7,15 +7,12 @@ import java.util.Set;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.scoreboard.Team.Option;
 import org.bukkit.scoreboard.Team.OptionStatus;
 
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.api.persistence.Persist;
-import net.citizensnpcs.Settings;
 import net.citizensnpcs.api.trait.Trait;
 import net.citizensnpcs.api.trait.TraitName;
 import net.citizensnpcs.util.NMS;
@@ -97,19 +94,6 @@ public class ScoreboardTrait extends Trait {
         }
         for (Player player : Bukkit.getOnlinePlayers()) {
             NMS.sendTeamPacket(player, team);
-        }
-    }
-
-    @EventHandler
-    public void onPlayerJoin(PlayerJoinEvent event) {
-        String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
-        Team team = null;
-        if (!(npc.getEntity() instanceof Player) || teamName.length() == 0
-                || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
-            return;
-
-        if (Settings.Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-            NMS.sendTeamPacket(event.getPlayer(), team);
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/util/NMS.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMS.java
@@ -362,6 +362,10 @@ public class NMS {
         BRIDGE.sendTabListRemove(recipient, listPlayer);
     }
 
+    public static void sendTeamPacket(Player recipient, Team team) {
+        BRIDGE.sendTeamPacket(recipient, team);
+    }
+
     public static void setBodyYaw(Entity entity, float yaw) {
         BRIDGE.setBodyYaw(entity, yaw);
     }

--- a/main/src/main/java/net/citizensnpcs/util/NMSBridge.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMSBridge.java
@@ -117,6 +117,8 @@ public interface NMSBridge {
 
     public void sendTabListRemove(Player recipient, Player listPlayer);
 
+    public void sendTeamPacket(Player recipient, Team team);
+
     public void setBodyYaw(Entity entity, float yaw);
 
     public void setDestination(Entity entity, double x, double y, double z, float speed);

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -855,6 +855,10 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+    }
+
+    @Override
     public void sendTabListRemove(Player recipient, Player listPlayer) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(listPlayer);

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -191,6 +191,7 @@ import net.minecraft.server.v1_10_R1.NetworkManager;
 import net.minecraft.server.v1_10_R1.Packet;
 import net.minecraft.server.v1_10_R1.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_10_R1.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_10_R1.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_10_R1.PathEntity;
 import net.minecraft.server.v1_10_R1.PathPoint;
 import net.minecraft.server.v1_10_R1.PathType;
@@ -856,6 +857,19 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -922,6 +922,10 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+    }
+
+    @Override
     public void setBodyYaw(org.bukkit.entity.Entity entity, float yaw) {
         getHandle(entity).yaw = yaw;
     }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -209,6 +209,7 @@ import net.minecraft.server.v1_11_R1.NetworkManager;
 import net.minecraft.server.v1_11_R1.Packet;
 import net.minecraft.server.v1_11_R1.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_11_R1.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_11_R1.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_11_R1.PathEntity;
 import net.minecraft.server.v1_11_R1.PathPoint;
 import net.minecraft.server.v1_11_R1.PathType;
@@ -923,6 +924,19 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -213,6 +213,7 @@ import net.minecraft.server.v1_12_R1.NetworkManager;
 import net.minecraft.server.v1_12_R1.Packet;
 import net.minecraft.server.v1_12_R1.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_12_R1.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_12_R1.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_12_R1.PathEntity;
 import net.minecraft.server.v1_12_R1.PathPoint;
 import net.minecraft.server.v1_12_R1.PathType;
@@ -920,6 +921,19 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -919,6 +919,10 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+    }
+
+    @Override
     public void sendTabListRemove(Player recipient, Player listPlayer) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(listPlayer);

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -228,6 +228,7 @@ import net.minecraft.server.v1_13_R2.NetworkManager;
 import net.minecraft.server.v1_13_R2.Packet;
 import net.minecraft.server.v1_13_R2.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_13_R2.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_13_R2.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_13_R2.PathEntity;
 import net.minecraft.server.v1_13_R2.PathPoint;
 import net.minecraft.server.v1_13_R2.PathType;
@@ -951,6 +952,23 @@ public class NMSImpl implements NMSBridge {
 
         NMSImpl.sendPacket(recipient,
                 new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, entities));
+    }
+
+    @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
@@ -247,6 +247,7 @@ import net.minecraft.server.v1_14_R1.NetworkManager;
 import net.minecraft.server.v1_14_R1.Packet;
 import net.minecraft.server.v1_14_R1.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_14_R1.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_14_R1.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_14_R1.PathEntity;
 import net.minecraft.server.v1_14_R1.PathPoint;
 import net.minecraft.server.v1_14_R1.PathType;
@@ -1014,6 +1015,23 @@ public class NMSImpl implements NMSBridge {
 
         NMSImpl.sendPacket(recipient,
                 new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, entity));
+    }
+
+    @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
@@ -248,6 +248,7 @@ import net.minecraft.server.v1_15_R1.NetworkManager;
 import net.minecraft.server.v1_15_R1.Packet;
 import net.minecraft.server.v1_15_R1.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_15_R1.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_15_R1.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_15_R1.PathEntity;
 import net.minecraft.server.v1_15_R1.PathPoint;
 import net.minecraft.server.v1_15_R1.PathType;
@@ -1017,6 +1018,23 @@ public class NMSImpl implements NMSBridge {
 
         NMSImpl.sendPacket(recipient,
                 new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, entity));
+    }
+
+    @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -83,6 +83,10 @@ public class HumanController extends AbstractEntityController {
                     team.addPlayer(handle.getBukkitEntity());
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
+
+                    for (Player player : Bukkit.getOnlinePlayers()) {
+                        NMS.sendTeamPacket(player, team);
+                    }
                 }
             }
         }, 20);

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
@@ -165,6 +165,7 @@ import net.minecraft.server.v1_8_R3.NetworkManager;
 import net.minecraft.server.v1_8_R3.Packet;
 import net.minecraft.server.v1_8_R3.PacketPlayOutEntityTeleport;
 import net.minecraft.server.v1_8_R3.PacketPlayOutPlayerInfo;
+import net.minecraft.server.v1_8_R3.PacketPlayOutScoreboardTeam;
 import net.minecraft.server.v1_8_R3.PathEntity;
 import net.minecraft.server.v1_8_R3.PathPoint;
 import net.minecraft.server.v1_8_R3.PathfinderGoalSelector;
@@ -783,6 +784,19 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void sendTeamPacket(Player recipient, Team team) {
+        Preconditions.checkNotNull(recipient);
+        Preconditions.checkNotNull(team);
+
+        if (TEAM_FIELD == null) {
+            TEAM_FIELD = NMS.getField(team.getClass(), "team");
+        }
+
+        try {
+            ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.get(team);
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
@@ -782,6 +782,10 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
+    public void sendTeamPacket(Player recipient, Team team) {
+    }
+
+    @Override
     public void sendTabListRemove(Player recipient, Player listPlayer) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(listPlayer);


### PR DESCRIPTION
This should fix incompatibility with scoreboard plugins that break the main scoreboard.

The Problem
-------------

A lot of scoreboard plugins will set the player scoreboard to something unique, instead of using the "main" scoreboard in Spigot.
The way Spigot handles these, is it does not share data across scoreboards. When a player has their own scoreboard, they do not see any values on the main scoreboard (or any others).
Citizens sets a lot of data on the main scoreboard (NPC name prefix/suffix being the most notable example).
So, when one of those scoreboard plugins that breaks the main scoreboard is in use, those Citizens features simply stop applying.
I've previously written a longer description of this on the wiki @ https://wiki.citizensnpcs.co/Plugin_Conflict#Addendum:_Technical_Note_On_Scoreboards
![wikiscreenshot](https://i.alexgoodwin.media/i/misc/a441e5.png)

Existing Solutions
------------------

The only existing solution currently is to use a scoreboard plugin that doesn't break the main scoreboard. The primary method to do this is via sending scoreboard packets instead of relying on the Spigot scoreboard system. This is implemented for example by the Denizen script "magic sidebar" @ https://forum.denizenscript.com/viewtopic.php?f=13&t=147

Unfortunately, most scoreboard plugins can't be bothered to do that.

This Solution
-------------

The solution presented by this PR is to flip the existing solution around: have Citizens' scoreboard data sent by packet, thus forcing it through even when the Spigot scoreboard is changed off main for players.

Testing And Implementation
-----------------------------

I've tested this on 1.15.2 and confirmed that it works as expected without noticeable errors.
I first replicated the problem on previous versions, by creating an NPC with a very long name, and setting my player scoreboard to one other than main. As expected, the NPC names were cut to the 16 character short limit.
After updating to a build of Citizens based on this PR, NPC names displayed the full length above 16 as expected, even when the player scoreboard was changed to various other values.

I foresee a potential limitation where a plugin might rapidly change the player's scoreboard, including to main and then elsewhere, which might cause teams to be removed from view by Spigot, but I've not been able to make anything go wrong in testing and I hope no scoreboard plugin is crazy enough to do that anyway. Worst case scenario, such a plugin would invalidate the benefit of this PR for servers running it, but not add any new issues.

I have not tested this on other versions, but have backported to 1.14.4 and 1.13.2 on the assumption that the very similar NMS backing means it'll work out fine. I have not backported to older Minecraft versions as I'm less sure of reliability, but that can be done at any time so long as somebody's willing to test those older versions.

Technical Details
-----------------

The idea is to more or less just blast packets out in 3 key event situations:
- New NPC created (via HumanController), send to all players
- Team info change (via `apply` in ScoreboardTrait), send to all players
- Player joins (via `onPlayerJoin` event in ScoreboardTrait), send to the joining players

To the best of my knowledge, this is sufficient coverage. This only does not cover cases where teams are changed without calling `apply`.
This might build up a bit of junk info on the client (by not removing scoreboard teams from the client), but that's a minuscule amount of data with no ill effect other than wasting a bit of client RAM and will be automatically cleared when the client disconnects anyway.

Extra Note
-----------

I did my best to follow existing standards and formats of the Citizens codebase, to the point of copypasting existing reference code even when my editor was annoyed about it (eg almost all the body code of `onPlayerJoin` is copied from `EventListen#onEntityDeath`). Also involved a bit of manual import management (as my editor would very much like to collapse that hundred+ NMS imports to just a `*`), and figuring out alphabetical order (since it appears methods are semi-consistently listed in that order).
