### PR TITLE
patch the majority of potential scoreboard packet errors

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -482,18 +482,8 @@ public class EventListen implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         skinUpdateTracker.updatePlayer(event.getPlayer(), 6 * 20, true);
 
-        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-            for (NPC npc : getAllNPCs()) {
-                if (!(npc.getEntity() instanceof Player)) {
-                    continue;
-                }
-                String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
-                Team team = null;
-                if (teamName.length() == 0 || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
-                    continue;
-
-                NMS.sendTeamPacket(event.getPlayer(), team);
-            }
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean() && !Util.isPlayerMainScoreboard(event.getPlayer())) {
+            Util.sendAllNpcTeamsTo(event.getPlayer(), 0);
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
@@ -4,9 +4,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.scoreboard.Team.Option;
 import org.bukkit.scoreboard.Team.OptionStatus;
@@ -92,9 +90,7 @@ public class ScoreboardTrait extends Trait {
                 }
             }
         }
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            NMS.sendTeamPacket(player, team);
-        }
+        Util.sendTeamPacketToAll(team, 2);
     }
 
     public void removeTag(String tag) {

--- a/main/src/main/java/net/citizensnpcs/util/NMS.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMS.java
@@ -366,8 +366,8 @@ public class NMS {
         BRIDGE.sendTabListRemove(recipient, listPlayer);
     }
 
-    public static void sendTeamPacket(Player recipient, Team team) {
-        BRIDGE.sendTeamPacket(recipient, team);
+    public static void sendTeamPacket(Player recipient, Team team, int mode) {
+        BRIDGE.sendTeamPacket(recipient, team, mode);
     }
 
     public static void setBodyYaw(Entity entity, float yaw) {

--- a/main/src/main/java/net/citizensnpcs/util/NMSBridge.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMSBridge.java
@@ -119,7 +119,7 @@ public interface NMSBridge {
 
     public void sendTabListRemove(Player recipient, Player listPlayer);
 
-    public void sendTeamPacket(Player recipient, Team team);
+    public void sendTeamPacket(Player recipient, Team team, int mode);
 
     public void setBodyYaw(Entity entity, float yaw);
 

--- a/main/src/main/java/net/citizensnpcs/util/PlayerUpdateTask.java
+++ b/main/src/main/java/net/citizensnpcs/util/PlayerUpdateTask.java
@@ -64,6 +64,10 @@ public class PlayerUpdateTask extends BukkitRunnable {
         PLAYERS.put(entity.getUniqueId(), (Player) entity);
     }
 
+    public static Iterable<Player> getRegisteredPlayerNPCs() {
+        return PLAYERS.values();
+    }
+
     private static Map<UUID, org.bukkit.entity.Player> PLAYERS = new HashMap<UUID, org.bukkit.entity.Player>();
     private static Map<UUID, org.bukkit.entity.Entity> TICKERS = new HashMap<UUID, org.bukkit.entity.Entity>();
     private static List<org.bukkit.entity.Entity> TICKERS_PENDING_ADD = new ArrayList<org.bukkit.entity.Entity>();

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -861,7 +861,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -871,7 +871,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -928,7 +928,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -938,7 +938,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -925,7 +925,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -935,7 +935,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -960,7 +960,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -970,7 +970,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
@@ -1023,7 +1023,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -1033,7 +1033,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
@@ -1026,7 +1026,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -1036,7 +1036,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -84,9 +84,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    for (Player player : Bukkit.getOnlinePlayers()) {
-                        NMS.sendTeamPacket(player, team);
-                    }
+                    Util.sendTeamPacketToAll(team, 0);
                 }
             }
         }, 20);
@@ -115,6 +113,7 @@ public class HumanController extends AbstractEntityController {
                         team.setSuffix("");
                     }
                     team.removePlayer(entity);
+                    Util.sendTeamPacketToAll(team, 1);
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
@@ -788,7 +788,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     @Override
-    public void sendTeamPacket(Player recipient, Team team) {
+    public void sendTeamPacket(Player recipient, Team team, int mode) {
         Preconditions.checkNotNull(recipient);
         Preconditions.checkNotNull(team);
 
@@ -798,7 +798,7 @@ public class NMSImpl implements NMSBridge {
 
         try {
             ScoreboardTeam nmsTeam = (ScoreboardTeam) TEAM_FIELD.get(team);
-            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, 0));
+            sendPacket(recipient, new PacketPlayOutScoreboardTeam(nmsTeam, mode));
         } catch (Throwable e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This fix has two main sub-fixes to it:
- Use the correct team packet mode (create, edit, remove) because the client will complain if create is used repeatedly for the same team. This includes bothering to send out remove packets, which I previously ignored.
- Track whether players are on the main scoreboard or a different one. Players on the main scoreboard will not be sent packets, as they already have the main scoreboard working.

The only known limitation is players on the non-main scoreboard that at any point switch to the main scoreboard will receive error messages in their logs, but those are (in my own testing at least) nonfatal and basically unnoticeable unless a player is watching their client logs closely.