### PR TITLE
simplify scoreboard patch to be 100% packet based

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -50,7 +50,6 @@ import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scoreboard.Team;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
@@ -287,16 +286,6 @@ public class EventListen implements Listener {
         final Location location = npc.getStoredLocation();
         Bukkit.getPluginManager().callEvent(new NPCDeathEvent(npc, event));
         npc.despawn(DespawnReason.DEATH);
-
-        if (npc.data().has(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA)) {
-            String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA);
-            Team team = Util.getDummyScoreboard().getTeam(teamName);
-            if (team != null) {
-                team.unregister();
-            }
-
-            npc.data().remove(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA);
-        }
 
         if (npc.data().get(NPC.RESPAWN_DELAY_METADATA, -1) >= 0) {
             int delay = npc.data().get(NPC.RESPAWN_DELAY_METADATA, -1);

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -290,7 +290,7 @@ public class EventListen implements Listener {
 
         if (npc.data().has(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA)) {
             String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA);
-            Team team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName);
+            Team team = Util.getDummyScoreboard().getTeam(teamName);
             if (team != null) {
                 team.unregister();
             }
@@ -482,7 +482,7 @@ public class EventListen implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         skinUpdateTracker.updatePlayer(event.getPlayer(), 6 * 20, true);
 
-        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean() && !Util.isPlayerMainScoreboard(event.getPlayer())) {
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
             Util.updateNPCTeams(event.getPlayer(), 0);
         }
     }

--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -402,7 +402,7 @@ public class CitizensNPC extends AbstractNPC {
         String teamName = data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
         Team team = null;
         if (!(getEntity() instanceof Player) || teamName.length() == 0
-                || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
+                || (team = Util.getDummyScoreboard().getTeam(teamName)) == null)
             return;
 
         if (!Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -3,7 +3,6 @@ package net.citizensnpcs.util;
 import java.util.EnumSet;
 import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
@@ -16,12 +15,12 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.util.Vector;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.collect.Sets;
 
 import net.citizensnpcs.api.event.NPCCollisionEvent;
 import net.citizensnpcs.api.event.NPCPushEvent;
@@ -84,6 +83,10 @@ public class Util {
         if (to == null || entity.getWorld() != to.getWorld())
             return;
         NMS.look(entity, to, headOnly, immediate);
+    }
+
+    public static Scoreboard getDummyScoreboard() {
+        return DUMMY_SCOREBOARD;
     }
 
     public static Location getEyeLocation(Entity entity) {
@@ -150,16 +153,6 @@ public class Util {
         } catch (NoSuchFieldError e) {
             return false;
         }
-    }
-
-    public static boolean isPlayerMainScoreboard(Player player) {
-        boolean isOnMain = player.getScoreboard().equals(Bukkit.getScoreboardManager().getMainScoreboard());
-        if (isOnMain) {
-            PLAYERS_ON_MAIN_SCOREBOARD.add(player.getUniqueId());
-        } else {
-            PLAYERS_ON_MAIN_SCOREBOARD.remove(player.getUniqueId());
-        }
-        return isOnMain;
     }
 
     public static String listValuesPretty(Enum<?>[] values) {
@@ -242,14 +235,7 @@ public class Util {
      */
     public static void sendTeamPacketToOnlinePlayers(Team team, int mode) {
         for (Player player : Bukkit.getOnlinePlayers()) {
-            boolean wasOnMain = PLAYERS_ON_MAIN_SCOREBOARD.contains(player.getUniqueId());
-            if (isPlayerMainScoreboard(player))
-                continue;
-            if (wasOnMain) {
-                updateNPCTeams(player, 0);
-            } else {
-                NMS.sendTeamPacket(player, team, mode);
-            }
+            NMS.sendTeamPacket(player, team, mode);
         }
     }
 
@@ -308,7 +294,7 @@ public class Util {
             String teamName = npc.data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
             Team team = null;
             if (teamName.length() == 0
-                    || (team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(teamName)) == null)
+                    || (team = Util.getDummyScoreboard().getTeam(teamName)) == null)
                 continue;
 
             NMS.sendTeamPacket(toUpdate, team, mode);
@@ -316,7 +302,7 @@ public class Util {
     }
 
     private static final Location AT_LOCATION = new Location(null, 0, 0, 0);
+    private static final Scoreboard DUMMY_SCOREBOARD = Bukkit.getScoreboardManager().getNewScoreboard();
     private static String MINECRAFT_REVISION;
     private static final Pattern NON_ALPHABET_MATCHER = Pattern.compile(".*[^A-Za-z0-9_].*");
-    private static final Set<UUID> PLAYERS_ON_MAIN_SCOREBOARD = Sets.newHashSet();
 }

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -71,8 +71,10 @@ public class HumanController extends AbstractEntityController {
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
+                    int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        mode = 0;
                     }
                     if (prefixCapture != null) {
                         team.setPrefix(prefixCapture);
@@ -84,7 +86,7 @@ public class HumanController extends AbstractEntityController {
 
                     handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
 
-                    Util.sendTeamPacketToOnlinePlayers(team, 0);
+                    Util.sendTeamPacketToOnlinePlayers(team, mode);
                 }
             }
         }, 20);
@@ -109,11 +111,12 @@ public class HumanController extends AbstractEntityController {
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {
-                        team.setPrefix("");
-                        team.setSuffix("");
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
                     }
-                    team.removePlayer(entity);
-                    Util.sendTeamPacketToOnlinePlayers(team, 1);
+                    else {
+                        team.removePlayer(entity);
+                    }
                 }
             }
             NMS.removeFromWorld(entity);

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -67,7 +67,7 @@ public class HumanController extends AbstractEntityController {
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                    Scoreboard scoreboard = Util.getDummyScoreboard();
                     String teamName = profile.getId().toString().substring(0, 16);
 
                     Team team = scoreboard.getTeam(teamName);
@@ -105,7 +105,7 @@ public class HumanController extends AbstractEntityController {
         if (entity != null) {
             if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                 String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+                Scoreboard scoreboard = Util.getDummyScoreboard();
                 Team team = scoreboard.getTeam(teamName);
                 if (team != null && team.hasPlayer(entity)) {
                     if (team.getSize() == 1) {


### PR DESCRIPTION
This fixes edge case errors related to Spigot scoreboard swapping.

The fundamental idea of the fix is: just stop using the main Spigot scoreboard entirely. The scoreboard entries for NPCs are now 100% packet based (which in hindsight is what I should've done from the start and I'm not sure why I tried to keep it on the Spigot main board).

This also adds some protections against the possibility of clientside errors if multiple NPCs end up on the same team (Theoretically a roughly 1 in 16^13 chance, but, I don't trust UUIDs to be as unique as bit width implies, especially given there seems to be preexisting code trying to catch that possibility) (eg a plugin might manually set UUIDs to non-random values).

I've tested the full range of possible screwery I can think of, including switching around Spigot scoreboards, creating/deleting NPCs with long names, renaming NPCs with long names, applying other scoreboard effects like glowing color, disconnecting&rejoining, etc. and have not been able to get any client errors at all anymore (in 1.15.2).