### PR TITLE
Reduce potential for errors with packet teams

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -50,6 +50,7 @@ import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scoreboard.Team;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
@@ -416,6 +417,23 @@ public class EventListen implements Listener {
                     + event.getReason().name());
         }
         skinUpdateTracker.onNPCDespawn(event.getNPC());
+        if (event.getNPC().getEntity() instanceof Player && !event.isCancelled()
+                && Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            String teamName = event.getNPC().data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
+            if (teamName.length() > 0) {
+                Player player = (Player) event.getNPC().getEntity();
+                Team team = Util.getDummyScoreboard().getTeam(teamName);
+                if (team != null && team.hasPlayer(player)) {
+                    if (team.getSize() == 1) {
+                        Util.sendTeamPacketToOnlinePlayers(team, 1);
+                        team.unregister();
+                    }
+                    else {
+                        team.removePlayer(player);
+                    }
+                }
+            }
+        }
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -417,8 +417,7 @@ public class EventListen implements Listener {
                     + event.getReason().name());
         }
         skinUpdateTracker.onNPCDespawn(event.getNPC());
-        if (event.getNPC().getEntity() instanceof Player && !event.isCancelled()
-                && Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+        if (event.getNPC().getEntity() instanceof Player && Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
             String teamName = event.getNPC().data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
             if (teamName.length() > 0) {
                 Player player = (Player) event.getNPC().getEntity();

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -4,6 +4,7 @@ import java.util.EnumSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -102,6 +103,10 @@ public class Util {
             MINECRAFT_REVISION = Bukkit.getServer().getClass().getPackage().getName();
         }
         return MINECRAFT_REVISION.substring(MINECRAFT_REVISION.lastIndexOf('.') + 2);
+    }
+
+    public static String getTeamName(UUID id) {
+        return "CIT-" + id.toString().replace("-", "").substring(0, 12);
     }
 
     public static boolean isAlwaysFlyable(EntityType type) {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -68,7 +68,7 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = profile.getId().toString().substring(0, 16);
+                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;
@@ -105,20 +105,6 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
-            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                String teamName = entity.getUniqueId().toString().substring(0, 16);
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-                Team team = scoreboard.getTeam(teamName);
-                if (team != null && team.hasPlayer(entity)) {
-                    if (team.getSize() == 1) {
-                        Util.sendTeamPacketToOnlinePlayers(team, 1);
-                        team.unregister();
-                    }
-                    else {
-                        team.removePlayer(entity);
-                    }
-                }
-            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();


### PR DESCRIPTION
Move scoreboard removal out of NMS to event method, and make more unique names.

This has:
- Cleaner code (by removing the duplication)
- Team removal reliability. I think `HumanController#remove` isn't reliably called in all despawn cases, so this helps that.
- Newer, uniquer, team names.
    - I realized it's possible that old scoreboard teams from previous builds might be stuck on the main board, and thus conflict with the packet based system. This might be the source of non-replicable errors we've seen reported.
    - The new team names basically guarantee that packet-based NPC teams won't share a name with old style team names.
    - It also makes the names more clear in purpose (the `CIT-` prefix to identify the team as being made by Citizens should it be spotted in some debugging somewhere).
    - The statistical uniqueness level isn't reduced much by the change, as the original team names had 3 static characters (two `-` and one `2` uuid version flag on the end) - the new name has none of those, but does have the static 4 character `CIT-` prefix.
    - The prefix also means that it's much less likely any other plugin will have any reason to make a team by the same name.