### PR TITLE
Cleanup for Imports and Generics

### DIFF
--- a/main/src/main/java/net/citizensnpcs/NPCNeedsRespawnEvent.java
+++ b/main/src/main/java/net/citizensnpcs/NPCNeedsRespawnEvent.java
@@ -1,10 +1,10 @@
 package net.citizensnpcs;
 
-import net.citizensnpcs.api.event.NPCEvent;
-import net.citizensnpcs.api.npc.NPC;
-
 import org.bukkit.Location;
 import org.bukkit.event.HandlerList;
+
+import net.citizensnpcs.api.event.NPCEvent;
+import net.citizensnpcs.api.npc.NPC;
 
 public class NPCNeedsRespawnEvent extends NPCEvent {
     private final Location spawn;

--- a/main/src/main/java/net/citizensnpcs/PaymentListener.java
+++ b/main/src/main/java/net/citizensnpcs/PaymentListener.java
@@ -1,16 +1,16 @@
 package net.citizensnpcs;
 
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import com.google.common.base.Preconditions;
+
 import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.api.event.PlayerCreateNPCEvent;
 import net.citizensnpcs.api.util.Messaging;
 import net.citizensnpcs.util.Messages;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
-
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-
-import com.google.common.base.Preconditions;
 
 public class PaymentListener implements Listener {
     private final Economy provider;

--- a/main/src/main/java/net/citizensnpcs/Settings.java
+++ b/main/src/main/java/net/citizensnpcs/Settings.java
@@ -92,7 +92,7 @@ public class Settings {
         DEFAULT_TEXT("npc.default.text.0", "Hi, I'm <npc>!") {
             @Override
             public void loadFromKey(DataKey root) {
-                List<String> list = new ArrayList<String>();
+                List<String> list = new ArrayList<>();
                 for (DataKey key : root.getRelative("npc.default.text").getSubKeys())
                     list.add(key.getString(""));
                 value = list;

--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommandSelector.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommandSelector.java
@@ -2,6 +2,16 @@ package net.citizensnpcs.commands;
 
 import java.util.List;
 
+import org.bukkit.command.CommandSender;
+import org.bukkit.conversations.Conversable;
+import org.bukkit.conversations.Conversation;
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.conversations.NumericPrompt;
+import org.bukkit.conversations.Prompt;
+
+import com.google.common.collect.Lists;
+
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.command.CommandContext;
 import net.citizensnpcs.api.command.CommandMessages;
@@ -15,16 +25,6 @@ import net.citizensnpcs.api.npc.NPCRegistry;
 import net.citizensnpcs.api.util.Messaging;
 import net.citizensnpcs.util.Messages;
 import net.citizensnpcs.util.Util;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.conversations.Conversable;
-import org.bukkit.conversations.Conversation;
-import org.bukkit.conversations.ConversationContext;
-import org.bukkit.conversations.ConversationFactory;
-import org.bukkit.conversations.NumericPrompt;
-import org.bukkit.conversations.Prompt;
-
-import com.google.common.collect.Lists;
 
 public class NPCCommandSelector extends NumericPrompt {
     private final Callback callback;

--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -828,7 +828,7 @@ public class NPCCommands {
                 : CitizensAPI.getNPCRegistry();
         if (source == null)
             throw new CommandException();
-        List<NPC> npcs = new ArrayList<NPC>();
+        List<NPC> npcs = new ArrayList<>();
 
         if (args.hasFlag('a')) {
             for (NPC add : source.sorted()) {
@@ -1568,7 +1568,7 @@ public class NPCCommands {
     public void script(CommandContext args, CommandSender sender, NPC npc) {
         ScriptTrait trait = npc.getTrait(ScriptTrait.class);
         if (args.hasValueFlag("add")) {
-            List<String> files = new ArrayList<String>();
+            List<String> files = new ArrayList<>();
             for (String file : args.getFlag("add").split(",")) {
                 if (!trait.validateFile(file)) {
                     Messaging.sendErrorTr(sender, Messages.INVALID_SCRIPT_FILE, file);

--- a/main/src/main/java/net/citizensnpcs/commands/TemplateCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/TemplateCommands.java
@@ -4,6 +4,13 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
+import org.bukkit.command.CommandSender;
+
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
 import net.citizensnpcs.Citizens;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.command.Command;
@@ -15,13 +22,6 @@ import net.citizensnpcs.api.util.Messaging;
 import net.citizensnpcs.npc.Template;
 import net.citizensnpcs.npc.Template.TemplateBuilder;
 import net.citizensnpcs.util.Messages;
-
-import org.bukkit.command.CommandSender;
-
-import com.google.common.base.Function;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 @Requirements(selected = true, ownership = true)
 public class TemplateCommands {

--- a/main/src/main/java/net/citizensnpcs/editor/Editor.java
+++ b/main/src/main/java/net/citizensnpcs/editor/Editor.java
@@ -56,5 +56,5 @@ public abstract class Editor implements Listener {
         EDITING.clear();
     }
 
-    private static final Map<String, Editor> EDITING = new HashMap<String, Editor>();
+    private static final Map<String, Editor> EDITING = new HashMap<>();
 }

--- a/main/src/main/java/net/citizensnpcs/editor/Equipper.java
+++ b/main/src/main/java/net/citizensnpcs/editor/Equipper.java
@@ -1,8 +1,8 @@
 package net.citizensnpcs.editor;
 
-import net.citizensnpcs.api.npc.NPC;
-
 import org.bukkit.entity.Player;
+
+import net.citizensnpcs.api.npc.NPC;
 
 public interface Equipper {
     public void equip(Player equipper, NPC toEquip);

--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -95,7 +95,7 @@ public class CitizensNPC extends AbstractNPC {
         if (reason == DespawnReason.RELOAD) {
             unloadEvents();
         }
-        for (Trait trait : new ArrayList<Trait>(traits.values())) {
+        for (Trait trait : new ArrayList<>(traits.values())) {
             trait.onDespawn();
         }
         Messaging.debug("Despawned", getId(), "DespawnReason." + reason);

--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPCRegistry.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPCRegistry.java
@@ -32,7 +32,7 @@ import net.citizensnpcs.trait.MountTrait;
 import net.citizensnpcs.util.NMS;
 
 public class CitizensNPCRegistry implements NPCRegistry {
-    private final TIntObjectHashMap<NPC> npcs = new TIntObjectHashMap<NPC>();
+    private final TIntObjectHashMap<NPC> npcs = new TIntObjectHashMap<>();
     private final NPCDataStore saves;
     private final Map<UUID, NPC> uniqueNPCs = Maps.newHashMap();
 
@@ -150,7 +150,7 @@ public class CitizensNPCRegistry implements NPCRegistry {
 
     @Override
     public Iterable<NPC> sorted() {
-        List<NPC> vals = new ArrayList<NPC>(npcs.valueCollection());
+        List<NPC> vals = new ArrayList<>(npcs.valueCollection());
         Collections.sort(vals, NPC_COMPARATOR);
         return vals;
     }

--- a/main/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
@@ -292,7 +292,7 @@ public class CitizensNavigator implements Navigator, Runnable {
         if (!isNavigating())
             return;
         Iterator<NavigatorCallback> itr = localParams.callbacks().iterator();
-        List<NavigatorCallback> callbacks = new ArrayList<NavigatorCallback>();
+        List<NavigatorCallback> callbacks = new ArrayList<>();
         while (itr.hasNext()) {
             callbacks.add(itr.next());
             itr.remove();

--- a/main/src/main/java/net/citizensnpcs/npc/ai/speech/Chat.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/speech/Chat.java
@@ -60,7 +60,7 @@ public class Chat implements VocalChord {
         else { // Multiple recipients
             String text = Setting.CHAT_FORMAT_TO_TARGET.asString().replace("<npc>", npc.getName()).replace("<text>",
                     context.getMessage());
-            List<String> targetNames = new ArrayList<String>();
+            List<String> targetNames = new ArrayList<>();
             // Talk to each recipient
             for (Talkable entity : context) {
                 entity.talkTo(context, text, this);

--- a/main/src/main/java/net/citizensnpcs/npc/ai/speech/Chat.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/speech/Chat.java
@@ -3,6 +3,8 @@ package net.citizensnpcs.npc.ai.speech;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.entity.Entity;
+
 import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.ai.speech.SpeechContext;
@@ -10,8 +12,6 @@ import net.citizensnpcs.api.ai.speech.Talkable;
 import net.citizensnpcs.api.ai.speech.VocalChord;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.api.util.Messaging;
-
-import org.bukkit.entity.Entity;
 
 public class Chat implements VocalChord {
     public final String VOCAL_CHORD_NAME = "chat";

--- a/main/src/main/java/net/citizensnpcs/npc/ai/speech/CitizensSpeechFactory.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/speech/CitizensSpeechFactory.java
@@ -4,14 +4,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import net.citizensnpcs.api.ai.speech.SpeechFactory;
-import net.citizensnpcs.api.ai.speech.Talkable;
-import net.citizensnpcs.api.ai.speech.VocalChord;
-
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 
 import com.google.common.base.Preconditions;
+
+import net.citizensnpcs.api.ai.speech.SpeechFactory;
+import net.citizensnpcs.api.ai.speech.Talkable;
+import net.citizensnpcs.api.ai.speech.VocalChord;
 
 public class CitizensSpeechFactory implements SpeechFactory {
     Map<String, Class<? extends VocalChord>> registered = new HashMap<String, Class<? extends VocalChord>>();

--- a/main/src/main/java/net/citizensnpcs/npc/ai/speech/CitizensSpeechFactory.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/speech/CitizensSpeechFactory.java
@@ -14,7 +14,7 @@ import net.citizensnpcs.api.ai.speech.Talkable;
 import net.citizensnpcs.api.ai.speech.VocalChord;
 
 public class CitizensSpeechFactory implements SpeechFactory {
-    Map<String, Class<? extends VocalChord>> registered = new HashMap<String, Class<? extends VocalChord>>();
+    Map<String, Class<? extends VocalChord>> registered = new HashMap<>();
 
     @Override
     public VocalChord getVocalChord(Class<? extends VocalChord> clazz) {

--- a/main/src/main/java/net/citizensnpcs/npc/ai/speech/TalkableEntity.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/speech/TalkableEntity.java
@@ -1,5 +1,9 @@
 package net.citizensnpcs.npc.ai.speech;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.ai.speech.SpeechContext;
 import net.citizensnpcs.api.ai.speech.Talkable;
@@ -8,10 +12,6 @@ import net.citizensnpcs.api.ai.speech.event.SpeechBystanderEvent;
 import net.citizensnpcs.api.ai.speech.event.SpeechTargetedEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.api.util.Messaging;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Player;
 
 public class TalkableEntity implements Talkable {
     Entity entity;

--- a/main/src/main/java/net/citizensnpcs/npc/profile/ProfileFetchThread.java
+++ b/main/src/main/java/net/citizensnpcs/npc/profile/ProfileFetchThread.java
@@ -26,8 +26,8 @@ import net.citizensnpcs.api.CitizensAPI;
  */
 class ProfileFetchThread implements Runnable {
     private final ProfileFetcher profileFetcher = new ProfileFetcher();
-    private final Deque<ProfileRequest> queue = new ArrayDeque<ProfileRequest>();
-    private final Map<String, ProfileRequest> requested = new HashMap<String, ProfileRequest>(35);
+    private final Deque<ProfileRequest> queue = new ArrayDeque<>();
+    private final Map<String, ProfileRequest> requested = new HashMap<>(35);
     private final Object sync = new Object(); // sync for queue & requested fields
 
     ProfileFetchThread() {
@@ -114,7 +114,7 @@ class ProfileFetchThread implements Runnable {
             if (queue.isEmpty())
                 return;
 
-            requests = new ArrayList<ProfileRequest>(queue);
+            requests = new ArrayList<>(queue);
             queue.clear();
         }
 

--- a/main/src/main/java/net/citizensnpcs/npc/profile/ProfileRequest.java
+++ b/main/src/main/java/net/citizensnpcs/npc/profile/ProfileRequest.java
@@ -62,7 +62,7 @@ public class ProfileRequest {
         }
 
         if (handlers == null)
-            handlers = new ArrayDeque<ProfileFetchHandler>();
+            handlers = new ArrayDeque<>();
 
         handlers.addLast(handler);
     }

--- a/main/src/main/java/net/citizensnpcs/npc/skin/Skin.java
+++ b/main/src/main/java/net/citizensnpcs/npc/skin/Skin.java
@@ -37,7 +37,7 @@ public class Skin {
     private int fetchRetries = -1;
     private boolean hasFetched;
     private volatile boolean isValid = true;
-    private final Map<SkinnableEntity, Void> pending = new WeakHashMap<SkinnableEntity, Void>(15);
+    private final Map<SkinnableEntity, Void> pending = new WeakHashMap<>(15);
     private BukkitTask retryTask;
     private volatile Property skinData;
     private volatile UUID skinId;
@@ -286,7 +286,7 @@ public class Skin {
         skinId = profile.getId();
         skinData = Iterables.getFirst(profile.getProperties().get("textures"), null);
 
-        List<SkinnableEntity> entities = new ArrayList<SkinnableEntity>(pending.keySet());
+        List<SkinnableEntity> entities = new ArrayList<>(pending.keySet());
         for (SkinnableEntity entity : entities) {
             applyAndRespawn(entity);
         }
@@ -401,7 +401,7 @@ public class Skin {
         profile.getProperties().put("textures", skinProperty);
     }
 
-    private static final Map<String, Skin> CACHE = new HashMap<String, Skin>(20);
+    private static final Map<String, Skin> CACHE = new HashMap<>(20);
     public static final String CACHED_SKIN_UUID_METADATA = "cached-skin-uuid";
     public static final String CACHED_SKIN_UUID_NAME_METADATA = "cached-skin-uuid-name";
 }

--- a/main/src/main/java/net/citizensnpcs/npc/skin/SkinPacketTracker.java
+++ b/main/src/main/java/net/citizensnpcs/npc/skin/SkinPacketTracker.java
@@ -29,7 +29,7 @@ import net.citizensnpcs.util.NMS;
  */
 public class SkinPacketTracker {
     private final SkinnableEntity entity;
-    private final Map<UUID, PlayerEntry> inProgress = new HashMap<UUID, PlayerEntry>(Bukkit.getMaxPlayers() / 2);
+    private final Map<UUID, PlayerEntry> inProgress = new HashMap<>(Bukkit.getMaxPlayers() / 2);
 
     private boolean isRemoved;
     private Skin skin;

--- a/main/src/main/java/net/citizensnpcs/npc/skin/SkinUpdateTracker.java
+++ b/main/src/main/java/net/citizensnpcs/npc/skin/SkinUpdateTracker.java
@@ -36,8 +36,8 @@ import net.citizensnpcs.util.Util;
  * @see net.citizensnpcs.EventListen
  */
 public class SkinUpdateTracker {
-    private final Map<SkinnableEntity, Void> navigating = new WeakHashMap<SkinnableEntity, Void>(25);
-    private final Map<UUID, PlayerTracker> playerTrackers = new HashMap<UUID, PlayerTracker>(
+    private final Map<SkinnableEntity, Void> navigating = new WeakHashMap<>(25);
+    private final Map<UUID, PlayerTracker> playerTrackers = new HashMap<>(
             Math.max(128, Bukkit.getMaxPlayers() / 2));
     private final Map<String, NPCRegistry> registries;
     private final NPCNavigationUpdater updater = new NPCNavigationUpdater();
@@ -109,7 +109,7 @@ public class SkinUpdateTracker {
     }
 
     private List<SkinnableEntity> getNearbyNPCs(Player player, boolean reset, boolean checkFov) {
-        List<SkinnableEntity> results = new ArrayList<SkinnableEntity>();
+        List<SkinnableEntity> results = new ArrayList<>();
         PlayerTracker tracker = getTracker(player, reset);
         for (NPC npc : getAllNPCs()) {
             SkinnableEntity skinnable = getSkinnable(npc);
@@ -341,7 +341,7 @@ public class SkinUpdateTracker {
             if (navigating.isEmpty() || playerTrackers.isEmpty())
                 return;
 
-            List<SkinnableEntity> nearby = new ArrayList<SkinnableEntity>(10);
+            List<SkinnableEntity> nearby = new ArrayList<>(10);
             Collection<? extends Player> players = Bukkit.getOnlinePlayers();
 
             for (Player player : players) {
@@ -364,7 +364,7 @@ public class SkinUpdateTracker {
     // Updates players. Repeating task used to schedule updates without
     // causing excessive scheduling.
     private class NPCNavigationUpdater extends BukkitRunnable {
-        Queue<UpdateInfo> queue = new ArrayDeque<UpdateInfo>(20);
+        Queue<UpdateInfo> queue = new ArrayDeque<>(20);
 
         @Override
         public void run() {
@@ -378,7 +378,7 @@ public class SkinUpdateTracker {
     // Tracks player location and yaw to determine when the player should be updated
     // with nearby skins.
     private class PlayerTracker {
-        final Set<SkinnableEntity> fovVisibleSkins = new HashSet<SkinnableEntity>(20);
+        final Set<SkinnableEntity> fovVisibleSkins = new HashSet<>(20);
         boolean hasMoved;
         final Location location = new Location(null, 0, 0, 0);
         float lowerBound;

--- a/main/src/main/java/net/citizensnpcs/npc/skin/TabListRemover.java
+++ b/main/src/main/java/net/citizensnpcs/npc/skin/TabListRemover.java
@@ -26,7 +26,7 @@ import net.citizensnpcs.util.NMS;
  * </p>
  */
 public class TabListRemover {
-    private final Map<UUID, PlayerEntry> pending = new HashMap<UUID, PlayerEntry>(Bukkit.getMaxPlayers() / 2);
+    private final Map<UUID, PlayerEntry> pending = new HashMap<>(Bukkit.getMaxPlayers() / 2);
 
     TabListRemover() {
         Bukkit.getScheduler().runTaskTimer(CitizensAPI.getPlugin(), new Sender(), 2, 2);
@@ -104,7 +104,7 @@ public class TabListRemover {
 
     private class PlayerEntry {
         Player player;
-        Set<SkinnableEntity> toRemove = new HashSet<SkinnableEntity>(25);
+        Set<SkinnableEntity> toRemove = new HashSet<>(25);
 
         PlayerEntry(Player player) {
             this.player = player;
@@ -124,7 +124,7 @@ public class TabListRemover {
                 int listSize = Math.min(maxPacketEntries, entry.toRemove.size());
                 boolean sendAll = listSize == entry.toRemove.size();
 
-                List<SkinnableEntity> skinnableList = new ArrayList<SkinnableEntity>(listSize);
+                List<SkinnableEntity> skinnableList = new ArrayList<>(listSize);
 
                 int i = 0;
                 Iterator<SkinnableEntity> skinIterator = entry.toRemove.iterator();

--- a/main/src/main/java/net/citizensnpcs/trait/Anchors.java
+++ b/main/src/main/java/net/citizensnpcs/trait/Anchors.java
@@ -21,7 +21,7 @@ import net.citizensnpcs.util.Messages;
  */
 @TraitName("anchors")
 public class Anchors extends Trait {
-    private final List<Anchor> anchors = new ArrayList<Anchor>();
+    private final List<Anchor> anchors = new ArrayList<>();
 
     public Anchors() {
         super("anchors");

--- a/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
@@ -22,7 +22,7 @@ public class ScoreboardTrait extends Trait {
     private ChatColor color;
     private ChatColor previousGlowingColor;
     @Persist
-    private final Set<String> tags = new HashSet<String>();
+    private final Set<String> tags = new HashSet<>();
 
     public ScoreboardTrait() {
         super("scoreboardtrait");
@@ -33,7 +33,7 @@ public class ScoreboardTrait extends Trait {
     }
 
     public void apply(Team team, boolean nameVisibility) {
-        Set<String> newTags = new HashSet<String>(tags);
+        Set<String> newTags = new HashSet<>(tags);
         if (SUPPORT_TAGS) {
             try {
                 for (Iterator<String> iterator = npc.getEntity().getScoreboardTags().iterator(); iterator.hasNext();) {

--- a/main/src/main/java/net/citizensnpcs/trait/ScriptTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScriptTrait.java
@@ -27,8 +27,8 @@ import net.citizensnpcs.api.util.DataKey;
 @TraitName("scripttrait")
 public class ScriptTrait extends Trait {
     @Persist
-    public List<String> files = new ArrayList<String>();
-    private final List<RunnableScript> runnableScripts = new ArrayList<RunnableScript>();
+    public List<String> files = new ArrayList<>();
+    private final List<RunnableScript> runnableScripts = new ArrayList<>();
 
     public ScriptTrait() {
         super("scripttrait");

--- a/main/src/main/java/net/citizensnpcs/trait/text/PageChangePrompt.java
+++ b/main/src/main/java/net/citizensnpcs/trait/text/PageChangePrompt.java
@@ -1,13 +1,13 @@
 package net.citizensnpcs.trait.text;
 
-import net.citizensnpcs.api.util.Messaging;
-import net.citizensnpcs.util.Messages;
-
 import org.bukkit.ChatColor;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.NumericPrompt;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.entity.Player;
+
+import net.citizensnpcs.api.util.Messaging;
+import net.citizensnpcs.util.Messages;
 
 public class PageChangePrompt extends NumericPrompt {
     private final Text text;

--- a/main/src/main/java/net/citizensnpcs/trait/text/Text.java
+++ b/main/src/main/java/net/citizensnpcs/trait/text/Text.java
@@ -49,7 +49,7 @@ public class Text extends Trait implements Runnable, Toggleable, Listener, Conve
     private double range = Setting.DEFAULT_TALK_CLOSE_RANGE.asDouble();
     private boolean realisticLooker = Setting.DEFAULT_REALISTIC_LOOKING.asBoolean();
     private boolean talkClose = Setting.DEFAULT_TALK_CLOSE.asBoolean();
-    private final List<String> text = new ArrayList<String>();
+    private final List<String> text = new ArrayList<>();
 
     public Text() {
         super("text");

--- a/main/src/main/java/net/citizensnpcs/trait/text/TextAddPrompt.java
+++ b/main/src/main/java/net/citizensnpcs/trait/text/TextAddPrompt.java
@@ -1,13 +1,13 @@
 package net.citizensnpcs.trait.text;
 
-import net.citizensnpcs.api.util.Messaging;
-import net.citizensnpcs.util.Messages;
-
 import org.bukkit.ChatColor;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.StringPrompt;
 import org.bukkit.entity.Player;
+
+import net.citizensnpcs.api.util.Messaging;
+import net.citizensnpcs.util.Messages;
 
 public class TextAddPrompt extends StringPrompt {
     private final Text text;

--- a/main/src/main/java/net/citizensnpcs/trait/text/TextEditPrompt.java
+++ b/main/src/main/java/net/citizensnpcs/trait/text/TextEditPrompt.java
@@ -1,13 +1,13 @@
 package net.citizensnpcs.trait.text;
 
-import net.citizensnpcs.api.util.Messaging;
-import net.citizensnpcs.util.Messages;
-
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.StringPrompt;
+
+import net.citizensnpcs.api.util.Messaging;
+import net.citizensnpcs.util.Messages;
 
 public class TextEditPrompt extends StringPrompt {
     private final Text text;

--- a/main/src/main/java/net/citizensnpcs/trait/text/TextEditStartPrompt.java
+++ b/main/src/main/java/net/citizensnpcs/trait/text/TextEditStartPrompt.java
@@ -1,12 +1,12 @@
 package net.citizensnpcs.trait.text;
 
-import net.citizensnpcs.api.util.Messaging;
-import net.citizensnpcs.util.Messages;
-
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.StringPrompt;
 import org.bukkit.entity.Player;
+
+import net.citizensnpcs.api.util.Messaging;
+import net.citizensnpcs.util.Messages;
 
 public class TextEditStartPrompt extends StringPrompt {
     private final Text text;

--- a/main/src/main/java/net/citizensnpcs/trait/text/TextRemovePrompt.java
+++ b/main/src/main/java/net/citizensnpcs/trait/text/TextRemovePrompt.java
@@ -1,12 +1,12 @@
 package net.citizensnpcs.trait.text;
 
-import net.citizensnpcs.api.util.Messaging;
-import net.citizensnpcs.util.Messages;
-
 import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.StringPrompt;
 import org.bukkit.entity.Player;
+
+import net.citizensnpcs.api.util.Messaging;
+import net.citizensnpcs.util.Messages;
 
 public class TextRemovePrompt extends StringPrompt {
     private final Text text;

--- a/main/src/main/java/net/citizensnpcs/trait/waypoint/GuidedWaypointProvider.java
+++ b/main/src/main/java/net/citizensnpcs/trait/waypoint/GuidedWaypointProvider.java
@@ -87,7 +87,7 @@ public class GuidedWaypointProvider implements EnumerableWaypointProvider {
         }
         final Player player = (Player) sender;
         return new WaypointEditor() {
-            private final EntityMarkers<Waypoint> markers = new EntityMarkers<Waypoint>(EntityType.ITEM_FRAME);
+            private final EntityMarkers<Waypoint> markers = new EntityMarkers<>(EntityType.ITEM_FRAME);
             private boolean showPath;
 
             @Override

--- a/main/src/main/java/net/citizensnpcs/trait/waypoint/LinearWaypointProvider.java
+++ b/main/src/main/java/net/citizensnpcs/trait/waypoint/LinearWaypointProvider.java
@@ -183,7 +183,7 @@ public class LinearWaypointProvider implements EnumerableWaypointProvider {
 
         private LinearWaypointEditor(Player player) {
             this.player = player;
-            this.markers = new EntityMarkers<Waypoint>();
+            this.markers = new EntityMarkers<>();
         }
 
         @Override

--- a/main/src/main/java/net/citizensnpcs/trait/waypoint/LinearWaypointsCompleteEvent.java
+++ b/main/src/main/java/net/citizensnpcs/trait/waypoint/LinearWaypointsCompleteEvent.java
@@ -2,9 +2,9 @@ package net.citizensnpcs.trait.waypoint;
 
 import java.util.Iterator;
 
-import net.citizensnpcs.api.event.CitizensEvent;
-
 import org.bukkit.event.HandlerList;
+
+import net.citizensnpcs.api.event.CitizensEvent;
 
 public class LinearWaypointsCompleteEvent extends CitizensEvent {
     private Iterator<Waypoint> next;

--- a/main/src/main/java/net/citizensnpcs/trait/waypoint/WanderWaypointProvider.java
+++ b/main/src/main/java/net/citizensnpcs/trait/waypoint/WanderWaypointProvider.java
@@ -100,7 +100,7 @@ public class WanderWaypointProvider
     public WaypointEditor createEditor(final CommandSender sender, CommandContext args) {
         return new WaypointEditor() {
             boolean editingRegions = false;
-            EntityMarkers<Location> markers = new EntityMarkers<Location>();
+            EntityMarkers<Location> markers = new EntityMarkers<>();
 
             @Override
             public void begin() {

--- a/main/src/main/java/net/citizensnpcs/trait/waypoint/triggers/WaypointTrigger.java
+++ b/main/src/main/java/net/citizensnpcs/trait/waypoint/triggers/WaypointTrigger.java
@@ -1,8 +1,8 @@
 package net.citizensnpcs.trait.waypoint.triggers;
 
-import net.citizensnpcs.api.npc.NPC;
-
 import org.bukkit.Location;
+
+import net.citizensnpcs.api.npc.NPC;
 
 public interface WaypointTrigger {
     String description();

--- a/main/src/main/java/net/citizensnpcs/util/PlayerUpdateTask.java
+++ b/main/src/main/java/net/citizensnpcs/util/PlayerUpdateTask.java
@@ -84,10 +84,10 @@ public class PlayerUpdateTask extends BukkitRunnable {
         PLAYERS_PENDING_ADD.add(entity);
     }
 
-    private static Map<UUID, org.bukkit.entity.Player> PLAYERS = new HashMap<UUID, org.bukkit.entity.Player>();
-    private static List<org.bukkit.entity.Entity> PLAYERS_PENDING_ADD = new ArrayList<org.bukkit.entity.Entity>();
-    private static List<org.bukkit.entity.Entity> PLAYERS_PENDING_REMOVE = new ArrayList<org.bukkit.entity.Entity>();
-    private static Map<UUID, org.bukkit.entity.Entity> TICKERS = new HashMap<UUID, org.bukkit.entity.Entity>();
-    private static List<org.bukkit.entity.Entity> TICKERS_PENDING_ADD = new ArrayList<org.bukkit.entity.Entity>();
-    private static List<org.bukkit.entity.Entity> TICKERS_PENDING_REMOVE = new ArrayList<org.bukkit.entity.Entity>();
+    private static Map<UUID, org.bukkit.entity.Player> PLAYERS = new HashMap<>();
+    private static List<org.bukkit.entity.Entity> PLAYERS_PENDING_ADD = new ArrayList<>();
+    private static List<org.bukkit.entity.Entity> PLAYERS_PENDING_REMOVE = new ArrayList<>();
+    private static Map<UUID, org.bukkit.entity.Entity> TICKERS = new HashMap<>();
+    private static List<org.bukkit.entity.Entity> TICKERS_PENDING_ADD = new ArrayList<>();
+    private static List<org.bukkit.entity.Entity> TICKERS_PENDING_REMOVE = new ArrayList<>();
 }

--- a/main/src/main/java/net/citizensnpcs/util/StringHelper.java
+++ b/main/src/main/java/net/citizensnpcs/util/StringHelper.java
@@ -1,9 +1,9 @@
 package net.citizensnpcs.util;
 
+import org.bukkit.ChatColor;
+
 import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.api.util.Colorizer;
-
-import org.bukkit.ChatColor;
 
 public class StringHelper {
     public static String wrap(Object string) {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -2,7 +2,6 @@ package net.citizensnpcs.nms.v1_10_R1.entity;
 
 import java.util.UUID;
 
-import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
@@ -21,6 +20,7 @@ import net.citizensnpcs.npc.AbstractEntityController;
 import net.citizensnpcs.npc.skin.Skin;
 import net.citizensnpcs.npc.skin.SkinnableEntity;
 import net.citizensnpcs.util.NMS;
+import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.PlayerInteractManager;
 import net.minecraft.server.v1_10_R1.WorldServer;
 

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/VillagerController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/VillagerController.java
@@ -16,6 +16,7 @@ import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.BlockPosition;
 import net.minecraft.server.v1_10_R1.EntityHuman;
+import net.minecraft.server.v1_10_R1.EntityLightning;
 import net.minecraft.server.v1_10_R1.EntityVillager;
 import net.minecraft.server.v1_10_R1.EnumHand;
 import net.minecraft.server.v1_10_R1.IBlockData;
@@ -23,7 +24,6 @@ import net.minecraft.server.v1_10_R1.ItemStack;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.SoundEffect;
 import net.minecraft.server.v1_10_R1.World;
-import net.minecraft.server.v1_10_R1.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/EggController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/EggController.java
@@ -1,5 +1,15 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEgg;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.npc.AbstractEntityController;
@@ -10,16 +20,6 @@ import net.minecraft.server.v1_10_R1.EntityEgg;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
 import net.minecraft.server.v1_10_R1.WorldServer;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEgg;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.entity.Egg;
-import org.bukkit.entity.Entity;
-import org.bukkit.util.Vector;
 
 public class EggController extends AbstractEntityController {
     public EggController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/EnderCrystalController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/EnderCrystalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEnderCrystal;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityEnderCrystal;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEnderCrystal;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.entity.EnderCrystal;
-import org.bukkit.util.Vector;
 
 public class EnderCrystalController extends MobEntityController {
     public EnderCrystalController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/EnderSignalController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/EnderSignalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEnderSignal;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.entity.EnderSignal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityEnderSignal;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEnderSignal;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.entity.EnderSignal;
-import org.bukkit.util.Vector;
 
 public class EnderSignalController extends MobEntityController {
     public EnderSignalController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/ExperienceOrbController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/ExperienceOrbController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftExperienceOrb;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityExperienceOrb;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftExperienceOrb;
-import org.bukkit.entity.ExperienceOrb;
-import org.bukkit.util.Vector;
 
 public class ExperienceOrbController extends MobEntityController {
     public ExperienceOrbController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/FireworkController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/FireworkController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftFirework;
+import org.bukkit.entity.Firework;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityFireworks;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftFirework;
-import org.bukkit.entity.Firework;
-import org.bukkit.util.Vector;
 
 public class FireworkController extends MobEntityController {
     public FireworkController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/LeashController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/LeashController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftLeash;
+import org.bukkit.entity.LeashHitch;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityLeash;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftLeash;
-import org.bukkit.entity.LeashHitch;
-import org.bukkit.util.Vector;
 
 public class LeashController extends MobEntityController {
     public LeashController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/PaintingController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/PaintingController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPainting;
+import org.bukkit.entity.Painting;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityPainting;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftPainting;
-import org.bukkit.entity.Painting;
-import org.bukkit.util.Vector;
 
 public class PaintingController extends MobEntityController {
     public PaintingController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/SnowballController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/SnowballController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftSnowball;
+import org.bukkit.entity.Snowball;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntitySnowball;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftSnowball;
-import org.bukkit.entity.Snowball;
-import org.bukkit.util.Vector;
 
 public class SnowballController extends MobEntityController {
     public SnowballController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/TNTPrimedController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/TNTPrimedController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftTNTPrimed;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityTNTPrimed;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftTNTPrimed;
-import org.bukkit.entity.TNTPrimed;
-import org.bukkit.util.Vector;
 
 public class TNTPrimedController extends MobEntityController {
     public TNTPrimedController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/WitherSkullController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/nonliving/WitherSkullController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_10_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_10_R1.entity.CraftWitherSkull;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_10_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_10_R1.EntityWitherSkull;
 import net.minecraft.server.v1_10_R1.NBTTagCompound;
 import net.minecraft.server.v1_10_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_10_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_10_R1.entity.CraftWitherSkull;
-import org.bukkit.entity.WitherSkull;
-import org.bukkit.util.Vector;
 
 public class WitherSkullController extends MobEntityController {
     public WitherSkullController() {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/network/EmptyChannel.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/network/EmptyChannel.java
@@ -1,5 +1,7 @@
 package net.citizensnpcs.nms.v1_10_R1.network;
 
+import java.net.SocketAddress;
+
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
@@ -7,8 +9,6 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
-
-import java.net.SocketAddress;
 
 public class EmptyChannel extends AbstractChannel {
     private final ChannelConfig config = new DefaultChannelConfig(this);

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/network/EmptyNetworkManager.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/network/EmptyNetworkManager.java
@@ -19,6 +19,6 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet) {
+    public void sendPacket(Packet<?> packet) {
     }
 }

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -1457,7 +1457,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/PlayerPathfinder.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/PlayerPathfinder.java
@@ -13,7 +13,7 @@ import net.minecraft.server.v1_10_R1.PathPoint;
 
 public class PlayerPathfinder {
     private final Path a = new Path();
-    private final Set<PathPoint> b = new HashSet<PathPoint>();
+    private final Set<PathPoint> b = new HashSet<>();
     private final PathPoint[] c = new PathPoint[32];
     private final PlayerPathfinderNormal d;
 

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/PlayerPathfinderNormal.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/PlayerPathfinderNormal.java
@@ -370,7 +370,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
         localObject1 = new BlockPosition(this.b);
         Object localObject2 = a(this.b, localObject1.getX(), i, localObject1.getZ());
         if (this.b.a((PathType) localObject2) < 0.0F) {
-            HashSet<BlockPosition> localHashSet = new HashSet<BlockPosition>();
+            HashSet<BlockPosition> localHashSet = new HashSet<>();
             localHashSet.add(new BlockPosition(this.b.getBoundingBox().a, i, this.b.getBoundingBox().c));
             localHashSet.add(new BlockPosition(this.b.getBoundingBox().a, i, this.b.getBoundingBox().f));
             localHashSet.add(new BlockPosition(this.b.getBoundingBox().d, i, this.b.getBoundingBox().c));

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -2,7 +2,6 @@ package net.citizensnpcs.nms.v1_11_R1.entity;
 
 import java.util.UUID;
 
-import net.citizensnpcs.util.Util;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
@@ -21,6 +20,7 @@ import net.citizensnpcs.npc.AbstractEntityController;
 import net.citizensnpcs.npc.skin.Skin;
 import net.citizensnpcs.npc.skin.SkinnableEntity;
 import net.citizensnpcs.util.NMS;
+import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.PlayerInteractManager;
 import net.minecraft.server.v1_11_R1.WorldServer;
 

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/VillagerController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/VillagerController.java
@@ -18,6 +18,7 @@ import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.BlockPosition;
 import net.minecraft.server.v1_11_R1.EntityHuman;
+import net.minecraft.server.v1_11_R1.EntityLightning;
 import net.minecraft.server.v1_11_R1.EntityVillager;
 import net.minecraft.server.v1_11_R1.EnumHand;
 import net.minecraft.server.v1_11_R1.IBlockData;
@@ -25,7 +26,6 @@ import net.minecraft.server.v1_11_R1.MerchantRecipe;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.SoundEffect;
 import net.minecraft.server.v1_11_R1.World;
-import net.minecraft.server.v1_11_R1.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/EggController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/EggController.java
@@ -1,5 +1,15 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEgg;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.npc.AbstractEntityController;
@@ -10,16 +20,6 @@ import net.minecraft.server.v1_11_R1.EntityEgg;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
 import net.minecraft.server.v1_11_R1.WorldServer;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEgg;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.entity.Egg;
-import org.bukkit.entity.Entity;
-import org.bukkit.util.Vector;
 
 public class EggController extends AbstractEntityController {
     public EggController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/EnderCrystalController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/EnderCrystalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEnderCrystal;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityEnderCrystal;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEnderCrystal;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.entity.EnderCrystal;
-import org.bukkit.util.Vector;
 
 public class EnderCrystalController extends MobEntityController {
     public EnderCrystalController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/EnderSignalController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/EnderSignalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEnderSignal;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.entity.EnderSignal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityEnderSignal;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEnderSignal;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.entity.EnderSignal;
-import org.bukkit.util.Vector;
 
 public class EnderSignalController extends MobEntityController {
     public EnderSignalController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/ExperienceOrbController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/ExperienceOrbController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftExperienceOrb;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityExperienceOrb;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftExperienceOrb;
-import org.bukkit.entity.ExperienceOrb;
-import org.bukkit.util.Vector;
 
 public class ExperienceOrbController extends MobEntityController {
     public ExperienceOrbController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/FireworkController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/FireworkController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftFirework;
+import org.bukkit.entity.Firework;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityFireworks;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftFirework;
-import org.bukkit.entity.Firework;
-import org.bukkit.util.Vector;
 
 public class FireworkController extends MobEntityController {
     public FireworkController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/LeashController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/LeashController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftLeash;
+import org.bukkit.entity.LeashHitch;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityLeash;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftLeash;
-import org.bukkit.entity.LeashHitch;
-import org.bukkit.util.Vector;
 
 public class LeashController extends MobEntityController {
     public LeashController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/PaintingController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/PaintingController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPainting;
+import org.bukkit.entity.Painting;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityPainting;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftPainting;
-import org.bukkit.entity.Painting;
-import org.bukkit.util.Vector;
 
 public class PaintingController extends MobEntityController {
     public PaintingController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/SnowballController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/SnowballController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftSnowball;
+import org.bukkit.entity.Snowball;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntitySnowball;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftSnowball;
-import org.bukkit.entity.Snowball;
-import org.bukkit.util.Vector;
 
 public class SnowballController extends MobEntityController {
     public SnowballController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/TNTPrimedController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/TNTPrimedController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftTNTPrimed;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityTNTPrimed;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftTNTPrimed;
-import org.bukkit.entity.TNTPrimed;
-import org.bukkit.util.Vector;
 
 public class TNTPrimedController extends MobEntityController {
     public TNTPrimedController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/WitherSkullController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/nonliving/WitherSkullController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_11_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_11_R1.entity.CraftWitherSkull;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_11_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_11_R1.EntityWitherSkull;
 import net.minecraft.server.v1_11_R1.NBTTagCompound;
 import net.minecraft.server.v1_11_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_11_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_11_R1.entity.CraftWitherSkull;
-import org.bukkit.entity.WitherSkull;
-import org.bukkit.util.Vector;
 
 public class WitherSkullController extends MobEntityController {
     public WitherSkullController() {

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/network/EmptyChannel.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/network/EmptyChannel.java
@@ -1,5 +1,7 @@
 package net.citizensnpcs.nms.v1_11_R1.network;
 
+import java.net.SocketAddress;
+
 import io.netty.channel.AbstractChannel;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelConfig;
@@ -7,8 +9,6 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
-
-import java.net.SocketAddress;
 
 public class EmptyChannel extends AbstractChannel {
     private final ChannelConfig config = new DefaultChannelConfig(this);

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/network/EmptyNetworkManager.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/network/EmptyNetworkManager.java
@@ -19,6 +19,6 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet) {
+    public void sendPacket(Packet<?> packet) {
     }
 }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -1520,7 +1520,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/PlayerPathfinder.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/PlayerPathfinder.java
@@ -13,7 +13,7 @@ import net.minecraft.server.v1_11_R1.PathPoint;
 
 public class PlayerPathfinder {
     private final Path a = new Path();
-    private final Set<PathPoint> b = new HashSet<PathPoint>();
+    private final Set<PathPoint> b = new HashSet<>();
     private final PathPoint[] c = new PathPoint[32];
     private final PlayerPathfinderNormal d;
 

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/SilverfishController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/SilverfishController.java
@@ -1,7 +1,5 @@
 package net.citizensnpcs.nms.v1_12_R1.entity;
 
-import net.minecraft.server.v1_12_R1.DamageSource;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
@@ -17,6 +15,7 @@ import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.BlockPosition;
+import net.minecraft.server.v1_12_R1.DamageSource;
 import net.minecraft.server.v1_12_R1.EntitySilverfish;
 import net.minecraft.server.v1_12_R1.IBlockData;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/VillagerController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/VillagerController.java
@@ -19,6 +19,7 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.BlockPosition;
 import net.minecraft.server.v1_12_R1.DamageSource;
 import net.minecraft.server.v1_12_R1.EntityHuman;
+import net.minecraft.server.v1_12_R1.EntityLightning;
 import net.minecraft.server.v1_12_R1.EntityVillager;
 import net.minecraft.server.v1_12_R1.EnumHand;
 import net.minecraft.server.v1_12_R1.IBlockData;
@@ -26,7 +27,6 @@ import net.minecraft.server.v1_12_R1.MerchantRecipe;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.SoundEffect;
 import net.minecraft.server.v1_12_R1.World;
-import net.minecraft.server.v1_12_R1.EntityLightning;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/EggController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/EggController.java
@@ -1,5 +1,15 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEgg;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.npc.AbstractEntityController;
@@ -10,16 +20,6 @@ import net.minecraft.server.v1_12_R1.EntityEgg;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
 import net.minecraft.server.v1_12_R1.WorldServer;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEgg;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.entity.Egg;
-import org.bukkit.entity.Entity;
-import org.bukkit.util.Vector;
 
 public class EggController extends AbstractEntityController {
     public EggController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/EnderCrystalController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/EnderCrystalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEnderCrystal;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityEnderCrystal;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEnderCrystal;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.entity.EnderCrystal;
-import org.bukkit.util.Vector;
 
 public class EnderCrystalController extends MobEntityController {
     public EnderCrystalController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/EnderSignalController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/EnderSignalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEnderSignal;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.entity.EnderSignal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityEnderSignal;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEnderSignal;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.entity.EnderSignal;
-import org.bukkit.util.Vector;
 
 public class EnderSignalController extends MobEntityController {
     public EnderSignalController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/ExperienceOrbController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/ExperienceOrbController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftExperienceOrb;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityExperienceOrb;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftExperienceOrb;
-import org.bukkit.entity.ExperienceOrb;
-import org.bukkit.util.Vector;
 
 public class ExperienceOrbController extends MobEntityController {
     public ExperienceOrbController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/FireworkController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/FireworkController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftFirework;
+import org.bukkit.entity.Firework;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityFireworks;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftFirework;
-import org.bukkit.entity.Firework;
-import org.bukkit.util.Vector;
 
 public class FireworkController extends MobEntityController {
     public FireworkController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/LeashController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/LeashController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftLeash;
+import org.bukkit.entity.LeashHitch;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityLeash;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftLeash;
-import org.bukkit.entity.LeashHitch;
-import org.bukkit.util.Vector;
 
 public class LeashController extends MobEntityController {
     public LeashController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/PaintingController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/PaintingController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPainting;
+import org.bukkit.entity.Painting;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityPainting;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPainting;
-import org.bukkit.entity.Painting;
-import org.bukkit.util.Vector;
 
 public class PaintingController extends MobEntityController {
     public PaintingController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/SnowballController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/SnowballController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftSnowball;
+import org.bukkit.entity.Snowball;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntitySnowball;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftSnowball;
-import org.bukkit.entity.Snowball;
-import org.bukkit.util.Vector;
 
 public class SnowballController extends MobEntityController {
     public SnowballController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/TNTPrimedController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/TNTPrimedController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftTNTPrimed;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityTNTPrimed;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftTNTPrimed;
-import org.bukkit.entity.TNTPrimed;
-import org.bukkit.util.Vector;
 
 public class TNTPrimedController extends MobEntityController {
     public TNTPrimedController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/WitherSkullController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/nonliving/WitherSkullController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_12_R1.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftWitherSkull;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_12_R1.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_12_R1.EntityWitherSkull;
 import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_12_R1.entity.CraftWitherSkull;
-import org.bukkit.entity.WitherSkull;
-import org.bukkit.util.Vector;
 
 public class WitherSkullController extends MobEntityController {
     public WitherSkullController() {

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/network/EmptyNetworkManager.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/network/EmptyNetworkManager.java
@@ -19,6 +19,6 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet) {
+    public void sendPacket(Packet<?> packet) {
     }
 }

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -1528,7 +1528,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/PlayerPathfinderAbstract.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/PlayerPathfinderAbstract.java
@@ -10,7 +10,7 @@ import net.minecraft.server.v1_12_R1.PathfinderAbstract;
 public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
     protected IBlockAccess a;
     protected EntityHumanNPC b;
-    protected final IntHashMap<PathPoint> c = new IntHashMap<PathPoint>();
+    protected final IntHashMap<PathPoint> c = new IntHashMap<>();
     protected int d;
     protected int e;
     protected int f;

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/EggController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/EggController.java
@@ -1,5 +1,15 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEgg;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.entity.Egg;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.npc.AbstractEntityController;
@@ -10,16 +20,6 @@ import net.minecraft.server.v1_13_R2.EntityEgg;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
 import net.minecraft.server.v1_13_R2.WorldServer;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.CraftWorld;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEgg;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.entity.Egg;
-import org.bukkit.entity.Entity;
-import org.bukkit.util.Vector;
 
 public class EggController extends AbstractEntityController {
     public EggController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/EnderCrystalController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/EnderCrystalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEnderCrystal;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.entity.EnderCrystal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityEnderCrystal;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEnderCrystal;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.entity.EnderCrystal;
-import org.bukkit.util.Vector;
 
 public class EnderCrystalController extends MobEntityController {
     public EnderCrystalController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/EnderSignalController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/EnderSignalController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEnderSignal;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.entity.EnderSignal;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityEnderSignal;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEnderSignal;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.entity.EnderSignal;
-import org.bukkit.util.Vector;
 
 public class EnderSignalController extends MobEntityController {
     public EnderSignalController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/ExperienceOrbController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/ExperienceOrbController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftExperienceOrb;
+import org.bukkit.entity.ExperienceOrb;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityExperienceOrb;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftExperienceOrb;
-import org.bukkit.entity.ExperienceOrb;
-import org.bukkit.util.Vector;
 
 public class ExperienceOrbController extends MobEntityController {
     public ExperienceOrbController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/FireworkController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/FireworkController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftFirework;
+import org.bukkit.entity.Firework;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityFireworks;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftFirework;
-import org.bukkit.entity.Firework;
-import org.bukkit.util.Vector;
 
 public class FireworkController extends MobEntityController {
     public FireworkController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/LeashController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/LeashController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftLeash;
+import org.bukkit.entity.LeashHitch;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityLeash;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftLeash;
-import org.bukkit.entity.LeashHitch;
-import org.bukkit.util.Vector;
 
 public class LeashController extends MobEntityController {
     public LeashController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/PaintingController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/PaintingController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPainting;
+import org.bukkit.entity.Painting;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityPainting;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftPainting;
-import org.bukkit.entity.Painting;
-import org.bukkit.util.Vector;
 
 public class PaintingController extends MobEntityController {
     public PaintingController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/SnowballController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/SnowballController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftSnowball;
+import org.bukkit.entity.Snowball;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntitySnowball;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftSnowball;
-import org.bukkit.entity.Snowball;
-import org.bukkit.util.Vector;
 
 public class SnowballController extends MobEntityController {
     public SnowballController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/TNTPrimedController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/TNTPrimedController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftTNTPrimed;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityTNTPrimed;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftTNTPrimed;
-import org.bukkit.entity.TNTPrimed;
-import org.bukkit.util.Vector;
 
 public class TNTPrimedController extends MobEntityController {
     public TNTPrimedController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/WitherSkullController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/nonliving/WitherSkullController.java
@@ -1,5 +1,12 @@
 package net.citizensnpcs.nms.v1_13_R2.entity.nonliving;
 
+import org.bukkit.Bukkit;
+import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_13_R2.entity.CraftWitherSkull;
+import org.bukkit.entity.WitherSkull;
+import org.bukkit.util.Vector;
+
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_13_R2.entity.MobEntityController;
@@ -9,13 +16,6 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_13_R2.EntityWitherSkull;
 import net.minecraft.server.v1_13_R2.NBTTagCompound;
 import net.minecraft.server.v1_13_R2.World;
-
-import org.bukkit.Bukkit;
-import org.bukkit.craftbukkit.v1_13_R2.CraftServer;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftEntity;
-import org.bukkit.craftbukkit.v1_13_R2.entity.CraftWitherSkull;
-import org.bukkit.entity.WitherSkull;
-import org.bukkit.util.Vector;
 
 public class WitherSkullController extends MobEntityController {
     public WitherSkullController() {

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/network/EmptyNetworkManager.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/network/EmptyNetworkManager.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.nms.v1_13_R2.network;
 
 import java.io.IOException;
 
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.citizensnpcs.nms.v1_13_R2.util.NMSImpl;
 import net.minecraft.server.v1_13_R2.EnumProtocolDirection;
@@ -20,6 +21,7 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet, GenericFutureListener genericfuturelistener) {
+    public void sendPacket(Packet<?> packet,
+            GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
     }
 }

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -1624,7 +1624,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/PlayerNavigation.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/PlayerNavigation.java
@@ -1,11 +1,33 @@
 package net.citizensnpcs.nms.v1_13_R2.util;
 
+import java.lang.reflect.Method;
+
 import net.citizensnpcs.nms.v1_13_R2.entity.EntityHumanNPC;
 import net.citizensnpcs.util.BoundingBox;
 import net.citizensnpcs.util.NMS;
-import net.minecraft.server.v1_13_R2.*;
-
-import java.lang.reflect.Method;
+import net.minecraft.server.v1_13_R2.AttributeInstance;
+import net.minecraft.server.v1_13_R2.Block;
+import net.minecraft.server.v1_13_R2.BlockPosition;
+import net.minecraft.server.v1_13_R2.Blocks;
+import net.minecraft.server.v1_13_R2.ChunkCache;
+import net.minecraft.server.v1_13_R2.Entity;
+import net.minecraft.server.v1_13_R2.EntityInsentient;
+import net.minecraft.server.v1_13_R2.EntityTypes;
+import net.minecraft.server.v1_13_R2.GenericAttributes;
+import net.minecraft.server.v1_13_R2.IBlockData;
+import net.minecraft.server.v1_13_R2.MathHelper;
+import net.minecraft.server.v1_13_R2.MethodProfiler;
+import net.minecraft.server.v1_13_R2.NavigationAbstract;
+import net.minecraft.server.v1_13_R2.PathEntity;
+import net.minecraft.server.v1_13_R2.PathMode;
+import net.minecraft.server.v1_13_R2.PathPoint;
+import net.minecraft.server.v1_13_R2.PathType;
+import net.minecraft.server.v1_13_R2.Pathfinder;
+import net.minecraft.server.v1_13_R2.PathfinderAbstract;
+import net.minecraft.server.v1_13_R2.PathfinderNormal;
+import net.minecraft.server.v1_13_R2.SystemUtils;
+import net.minecraft.server.v1_13_R2.Vec3D;
+import net.minecraft.server.v1_13_R2.World;
 
 public class PlayerNavigation extends NavigationAbstract {
     protected EntityHumanNPC a;

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/PlayerPathfinderAbstract.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/PlayerPathfinderAbstract.java
@@ -10,7 +10,7 @@ import net.minecraft.server.v1_13_R2.PathfinderAbstract;
 public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
     protected IBlockAccess a;
     protected EntityHumanNPC b;
-    protected final IntHashMap<PathPoint> c = new IntHashMap<PathPoint>();
+    protected final IntHashMap<PathPoint> c = new IntHashMap<>();
     protected int d;
     protected int e;
     protected int f;

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/PlayerPathfinderNormal.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/PlayerPathfinderNormal.java
@@ -87,7 +87,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
 
     public PathType a(IBlockAccess var1, int var2, int var3, int var4, EntityHumanNPC var5, int var6, int var7,
             int var8, boolean var9, boolean var10) {
-        EnumSet var11 = EnumSet.noneOf(PathType.class);
+        EnumSet<PathType> var11 = EnumSet.noneOf(PathType.class);
         PathType var12 = PathType.BLOCKED;
         double var13 = var5.width / 2.0D;
         BlockPosition var15 = new BlockPosition(var5);
@@ -96,10 +96,10 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
             return PathType.FENCE;
         } else {
             PathType var16 = PathType.BLOCKED;
-            Iterator var17 = var11.iterator();
+            Iterator<PathType> var17 = var11.iterator();
 
             while (var17.hasNext()) {
-                PathType var18 = (PathType) var17.next();
+                PathType var18 = var17.next();
                 if (var5.a(var18) < 0.0F) {
                     return var18;
                 }
@@ -120,7 +120,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
     @Override
     public PathType a(IBlockAccess var1, int var2, int var3, int var4, EntityInsentient var5, int var6, int var7,
             int var8, boolean var9, boolean var10) {
-        EnumSet var11 = EnumSet.noneOf(PathType.class);
+        EnumSet<PathType> var11 = EnumSet.noneOf(PathType.class);
         PathType var12 = PathType.BLOCKED;
         double var13 = var5.width / 2.0D;
         BlockPosition var15 = new BlockPosition(var5);
@@ -129,10 +129,10 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
             return PathType.FENCE;
         } else {
             PathType var16 = PathType.BLOCKED;
-            Iterator var17 = var11.iterator();
+            Iterator<PathType> var17 = var11.iterator();
 
             while (var17.hasNext()) {
-                PathType var18 = (PathType) var17.next();
+                PathType var18 = var17.next();
                 if (var5.a(var18) < 0.0F) {
                     return var18;
                 }
@@ -151,7 +151,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
     }
 
     public PathType a(IBlockAccess var1, int var2, int var3, int var4, int var5, int var6, int var7, boolean var8,
-            boolean var9, EnumSet var10, PathType var11, BlockPosition var12) {
+            boolean var9, EnumSet<PathType> var10, PathType var11, BlockPosition var12) {
         for (int var13 = 0; var13 < var5; ++var13) {
             for (int var14 = 0; var14 < var6; ++var14) {
                 for (int var15 = 0; var15 < var7; ++var15) {
@@ -432,16 +432,16 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
         var2 = new BlockPosition(this.b);
         PathType var9 = this.a(this.b, var2.getX(), var1, var2.getZ());
         if (this.b.a(var9) < 0.0F) {
-            HashSet var4 = Sets.newHashSet();
+            HashSet<BlockPosition> var4 = Sets.newHashSet();
             bb = NMSBoundingBox.wrap(this.b.getBoundingBox());
             var4.add(new BlockPosition(bb.minX, var1, bb.minZ));
             var4.add(new BlockPosition(bb.minX, var1, bb.maxZ));
             var4.add(new BlockPosition(bb.maxX, var1, bb.minZ));
             var4.add(new BlockPosition(bb.maxX, var1, bb.maxZ));
-            Iterator var5 = var4.iterator();
+            Iterator<BlockPosition> var5 = var4.iterator();
 
             while (var5.hasNext()) {
-                BlockPosition var6 = (BlockPosition) var5.next();
+                BlockPosition var6 = var5.next();
                 PathType var7 = this.a(this.b, var6);
                 if (this.b.a(var7) >= 0.0F) {
                     return this.a(var6.getX(), var6.getY(), var6.getZ());

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/AreaEffectCloudController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/AreaEffectCloudController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftAreaEffectCloud;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ArmorStandController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ArmorStandController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftArmorStand;
@@ -13,6 +12,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EggController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EggController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
@@ -13,6 +12,7 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.AbstractEntityController;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EnderCrystalController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EnderCrystalController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEnderCrystal;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EnderPearlController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EnderPearlController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEnderPearl;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EnderSignalController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EnderSignalController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEnderSignal;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EvokerFangsController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/EvokerFangsController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -13,6 +12,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ExperienceOrbController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ExperienceOrbController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/FireworkController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/FireworkController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/FishingHookController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/FishingHookController.java
@@ -2,7 +2,6 @@ package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
 import java.util.UUID;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -15,6 +14,7 @@ import com.mojang.authlib.GameProfile;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.NMS;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ItemController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ItemController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -17,6 +16,7 @@ import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.AbstractEntityController;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ItemFrameController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ItemFrameController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -16,6 +15,7 @@ import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/LeashController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/LeashController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/PaintingController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/PaintingController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ShulkerBulletController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ShulkerBulletController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/SmallFireballController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/SmallFireballController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/SnowballController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/SnowballController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/SpectralArrowController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/SpectralArrowController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftArrow;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/TNTPrimedController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/TNTPrimedController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ThrownExpBottleController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ThrownExpBottleController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ThrownPotionController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ThrownPotionController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ThrownTridentController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/ThrownTridentController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/TippedArrowController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/TippedArrowController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftArrow;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/WitherSkullController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/nonliving/WitherSkullController.java
@@ -1,6 +1,5 @@
 package net.citizensnpcs.nms.v1_14_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_14_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_14_R1.entity.CraftEntity;
@@ -11,6 +10,7 @@ import org.bukkit.util.Vector;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
 import net.citizensnpcs.nms.v1_14_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/network/EmptyNetworkManager.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/network/EmptyNetworkManager.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.nms.v1_14_R1.network;
 
 import java.io.IOException;
 
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.citizensnpcs.nms.v1_14_R1.util.NMSImpl;
 import net.minecraft.server.v1_14_R1.EnumProtocolDirection;
@@ -20,6 +21,6 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet, GenericFutureListener genericfuturelistener) {
+    public void sendPacket(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
     }
 }

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
@@ -1681,7 +1681,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
@@ -302,7 +302,7 @@ public class NMSImpl implements NMSBridge {
         if (remove) {
             handle.world.getPlayers().remove(handle);
         } else if (!handle.world.getPlayers().contains(handle)) {
-            ((List) handle.world.getPlayers()).add(handle);
+            ((List<EntityPlayer>) handle.world.getPlayers()).add(handle);
         }
         // PlayerUpdateTask.addOrRemove(entity, remove);
     }
@@ -1219,8 +1219,7 @@ public class NMSImpl implements NMSBridge {
                 return true;
             } else if (!removeFromPlayerList) {
                 if (!entity.world.getPlayers().contains(entity)) {
-                    List list = entity.world.getPlayers();
-                    list.add(entity);
+                    ((WorldServer) entity.world).getPlayers().add((EntityPlayer) entity);
                 }
                 return true;
             } else {

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerNavigation.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerNavigation.java
@@ -207,7 +207,7 @@ public class PlayerNavigation extends NavigationAbstract {
     }
 
     @Override
-    protected PathEntity a(Set var0, int var1, boolean var2, int var3) {
+    protected PathEntity a(Set<BlockPosition> var0, int var1, boolean var2, int var3) {
         if (var0.isEmpty()) {
             return null;
         } else if (this.a.locY < 0.0D) {
@@ -234,8 +234,8 @@ public class PlayerNavigation extends NavigationAbstract {
     }
 
     @Override
-    public PathEntity a(Stream var0, int var1) {
-        return this.a((Set) var0.collect(Collectors.toSet()), 8, false, var1);
+    public PathEntity a(Stream<BlockPosition> var0, int var1) {
+        return this.a(var0.collect(Collectors.toSet()), 8, false, var1);
     }
 
     @Override
@@ -353,7 +353,7 @@ public class PlayerNavigation extends NavigationAbstract {
 
     private boolean b(int var0, int var1, int var2, int var3, int var4, int var5, Vec3D var6, double var7,
             double var9) {
-        Iterator var12 = BlockPosition.a(new BlockPosition(var0, var1, var2),
+        Iterator<BlockPosition> var12 = BlockPosition.a(new BlockPosition(var0, var1, var2),
                 new BlockPosition(var0 + var3 - 1, var1 + var4 - 1, var2 + var5 - 1)).iterator();
 
         BlockPosition var14;
@@ -364,7 +364,7 @@ public class PlayerNavigation extends NavigationAbstract {
                 return true;
             }
 
-            var14 = (BlockPosition) var12.next();
+            var14 = var12.next();
             var13 = var14.getX() + 0.5D - var6.x;
             var15 = var14.getZ() + 0.5D - var6.z;
         } while (var13 * var7 + var15 * var9 < 0.0D || this.b.getType(var14).a(this.b, var14, PathMode.LAND));

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerPathfinder.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerPathfinder.java
@@ -26,7 +26,8 @@ import net.minecraft.server.v1_14_R1.Pathfinder;
 
 public class PlayerPathfinder extends Pathfinder {
     private final Path a = new Path();
-    private final Set b = Sets.newHashSet();
+    @SuppressWarnings("rawtypes")
+	private final Set b = Sets.newHashSet();
     private final PathPoint[] c = new PathPoint[32];
     private final int d;
     private final PlayerPathfinderNormal e;
@@ -42,7 +43,7 @@ public class PlayerPathfinder extends Pathfinder {
         this.a.a();
         this.e.a(var0, var1);
         PathPoint var5 = this.e.b();
-        Map var6 = var2.stream().collect(Collectors.toMap((var0x) -> {
+        Map<PathDestination, BlockPosition> var6 = var2.stream().collect(Collectors.toMap((var0x) -> {
             return this.e.a((double) var0x.getX(), (double) var0x.getY(), (double) var0x.getZ());
         }, Function.identity()));
         PathEntity var7 = this.a(var5, var6, var3, var4);
@@ -55,7 +56,7 @@ public class PlayerPathfinder extends Pathfinder {
         this.a.a();
         this.e.a(var0, var1);
         PathPoint var5 = this.e.b();
-        Map var6 = var2.stream().collect(Collectors.toMap((var0x) -> {
+        Map<PathDestination, BlockPosition> var6 = var2.stream().collect(Collectors.toMap((var0x) -> {
             return this.e.a((double) var0x.getX(), (double) var0x.getY(), (double) var0x.getZ());
         }, Function.identity()));
         PathEntity var7 = this.a(var5, var6, var3, var4);
@@ -64,7 +65,7 @@ public class PlayerPathfinder extends Pathfinder {
     }
 
     private PathEntity a(PathPoint var0, BlockPosition var1, boolean var2) {
-        List var3 = Lists.newArrayList();
+        List<PathPoint> var3 = Lists.newArrayList();
         PathPoint var4 = var0;
         var3.add(0, var0);
 
@@ -76,7 +77,7 @@ public class PlayerPathfinder extends Pathfinder {
         return new PathEntity(var3, var1, var2);
     }
 
-    private PathEntity a(PathPoint var0, Map var1, float var2, int var3) {
+    private PathEntity a(PathPoint var0, Map<PathDestination, BlockPosition> var1, float var2, int var3) {
         Set<PathDestination> var4 = var1.keySet();
         var0.e = 0.0F;
         var0.f = this.a(var0, var4);
@@ -124,30 +125,30 @@ public class PlayerPathfinder extends Pathfinder {
             }
         }
 
-        Stream var6;
+        Stream<PathEntity> var6;
         if (var4.stream().anyMatch(PathDestination::f)) {
             var6 = var4.stream().filter(PathDestination::f).map((var1x) -> {
-                return this.a(var1x.d(), (BlockPosition) var1.get(var1x), true);
+                return this.a(var1x.d(), var1.get(var1x), true);
             }).sorted(Comparator.comparingInt(PathEntity::e));
         } else {
             var6 = getFallbackDestinations(var1, var4);
         }
 
-        Optional var7 = var6.findFirst();
+        Optional<PathEntity> var7 = var6.findFirst();
         if (!var7.isPresent()) {
             return null;
         } else {
-            PathEntity var8 = (PathEntity) var7.get();
+            PathEntity var8 = var7.get();
             return var8;
         }
     }
 
-    private float a(PathPoint var0, Set var1) {
+    private float a(PathPoint var0, Set<PathDestination> var1) {
         float var2 = Float.MAX_VALUE;
 
         float var5;
-        for (Iterator var4 = var1.iterator(); var4.hasNext(); var2 = Math.min(var5, var2)) {
-            PathDestination var3 = (PathDestination) var4.next();
+        for (Iterator<PathDestination> var4 = var1.iterator(); var4.hasNext(); var2 = Math.min(var5, var2)) {
+            PathDestination var3 = var4.next();
             var5 = var0.a(var3);
             var3.a(var5, var0);
         }

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerPathfinderAbstract.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerPathfinderAbstract.java
@@ -12,7 +12,7 @@ import net.minecraft.server.v1_14_R1.PathfinderAbstract;
 public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
     protected IWorldReader a;
     protected EntityHumanNPC b;
-    protected final Int2ObjectMap c = new Int2ObjectOpenHashMap();
+    protected final Int2ObjectMap<PathPoint> c = new Int2ObjectOpenHashMap<>();
     protected int d;
     protected int e;
     protected int f;
@@ -33,7 +33,7 @@ public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
 
     @Override
     protected PathPoint a(int var0, int var1, int var2) {
-        return (PathPoint) this.c.computeIfAbsent(PathPoint.b(var0, var1, var2), (var3) -> {
+        return this.c.computeIfAbsent(PathPoint.b(var0, var1, var2), (var3) -> {
             return new PathPoint(var0, var1, var2);
         });
     }

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerPathfinderNormal.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerPathfinderNormal.java
@@ -113,7 +113,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
 
     public PathType a(IBlockAccess var0, int var1, int var2, int var3, EntityHumanNPC var4, int var5, int var6,
             int var7, boolean var8, boolean var9) {
-        EnumSet var10 = EnumSet.noneOf(PathType.class);
+        EnumSet<PathType> var10 = EnumSet.noneOf(PathType.class);
         PathType var11 = PathType.BLOCKED;
         double var12 = var4.getWidth() / 2.0D;
         BlockPosition var14 = new BlockPosition(var4);
@@ -122,10 +122,10 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
             return PathType.FENCE;
         } else {
             PathType var15 = PathType.BLOCKED;
-            Iterator var17 = var10.iterator();
+            Iterator<PathType> var17 = var10.iterator();
 
             while (var17.hasNext()) {
-                PathType var16 = (PathType) var17.next();
+                PathType var16 = var17.next();
                 if (var4.a(var16) < 0.0F) {
                     return var16;
                 }
@@ -146,7 +146,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
     @Override
     public PathType a(IBlockAccess var0, int var1, int var2, int var3, EntityInsentient var4, int var5, int var6,
             int var7, boolean var8, boolean var9) {
-        EnumSet var10 = EnumSet.noneOf(PathType.class);
+        EnumSet<PathType> var10 = EnumSet.noneOf(PathType.class);
         PathType var11 = PathType.BLOCKED;
         double var12 = var4.getWidth() / 2.0D;
         BlockPosition var14 = new BlockPosition(var4);
@@ -155,10 +155,10 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
             return PathType.FENCE;
         } else {
             PathType var15 = PathType.BLOCKED;
-            Iterator var17 = var10.iterator();
+            Iterator<PathType> var17 = var10.iterator();
 
             while (var17.hasNext()) {
-                PathType var16 = (PathType) var17.next();
+                PathType var16 = var17.next();
                 if (var4.a(var16) < 0.0F) {
                     return var16;
                 }
@@ -177,7 +177,7 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
     }
 
     public PathType a(IBlockAccess var0, int var1, int var2, int var3, int var4, int var5, int var6, boolean var7,
-            boolean var8, EnumSet var9, PathType var10, BlockPosition var11) {
+            boolean var8, EnumSet<PathType> var9, PathType var10, BlockPosition var11) {
         for (int var12 = 0; var12 < var4; ++var12) {
             for (int var13 = 0; var13 < var5; ++var13) {
                 for (int var14 = 0; var14 < var6; ++var14) {
@@ -450,15 +450,15 @@ public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
         var1 = new BlockPosition(this.b);
         PathType var2 = this.a(this.b, var1.getX(), var0, var1.getZ());
         if (this.b.a(var2) < 0.0F) {
-            Set var3 = Sets.newHashSet();
+            Set<BlockPosition> var3 = Sets.newHashSet();
             var3.add(new BlockPosition(this.b.getBoundingBox().minX, var0, this.b.getBoundingBox().minZ));
             var3.add(new BlockPosition(this.b.getBoundingBox().minX, var0, this.b.getBoundingBox().maxZ));
             var3.add(new BlockPosition(this.b.getBoundingBox().maxX, var0, this.b.getBoundingBox().minZ));
             var3.add(new BlockPosition(this.b.getBoundingBox().maxX, var0, this.b.getBoundingBox().maxZ));
-            Iterator var5 = var3.iterator();
+            Iterator<BlockPosition> var5 = var3.iterator();
 
             while (var5.hasNext()) {
-                BlockPosition var4 = (BlockPosition) var5.next();
+                BlockPosition var4 = var5.next();
                 PathType var6 = this.a(this.b, var4);
                 if (this.b.a(var6) >= 0.0F) {
                     return this.a(var4.getX(), var4.getY(), var4.getZ());

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/BatController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/BatController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftBat;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBat;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;
 import net.minecraft.server.v1_15_R1.SoundEffect;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/BeeController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/BeeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftBee;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBee;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;
 import net.minecraft.server.v1_15_R1.SoundEffect;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/BlazeController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/BlazeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftBlaze;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBlaze;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;
 import net.minecraft.server.v1_15_R1.SoundEffect;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CatController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CatController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftCat;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityCat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CaveSpiderController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CaveSpiderController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftCaveSpider;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityCaveSpider;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ChickenController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ChickenController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftChicken;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityChicken;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CodController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CodController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftCod;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityCod;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CowController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CowController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftCow;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityCow;
 import net.minecraft.server.v1_15_R1.EntityHuman;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EnumHand;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CreeperController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/CreeperController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftCreeper;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityCreeper;
 import net.minecraft.server.v1_15_R1.EntityLightning;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/DolphinController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/DolphinController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftDolphin;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityDolphin;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/DrownedController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/DrownedController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftDrowned;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityDrowned;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EnderDragonController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EnderDragonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEnderDragon;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityEnderDragon;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;
 import net.minecraft.server.v1_15_R1.SoundEffect;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EndermanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EndermanController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEnderman;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityEnderman;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EndermiteController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EndermiteController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEndermite;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityEndermite;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EvokerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EvokerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEvoker;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityEvoker;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/FoxController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/FoxController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftFox;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityFox;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GhastController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GhastController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftGhast;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityGhast;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;
 import net.minecraft.server.v1_15_R1.SoundEffect;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GiantController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GiantController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftGiant;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityGiantZombie;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GuardianController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GuardianController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftGuardian;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityGuardian;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GuardianElderController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/GuardianElderController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftElderGuardian;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityGuardianElder;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHorse;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.GenericAttributes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseDonkeyController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseDonkeyController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftDonkey;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHorseDonkey;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.GenericAttributes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseMuleController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseMuleController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHorseMule;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.GenericAttributes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseSkeletonController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseSkeletonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHorseSkeleton;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.GenericAttributes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseZombieController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HorseZombieController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHorseZombie;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.GenericAttributes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/IllusionerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/IllusionerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftIllusioner;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityIllagerIllusioner;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/IronGolemController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/IronGolemController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftIronGolem;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityIronGolem;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/LlamaController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/LlamaController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -24,6 +23,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityLlama;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/MagmaCubeController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/MagmaCubeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftMagmaCube;
@@ -23,6 +22,7 @@ import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHuman;
 import net.minecraft.server.v1_15_R1.EntityMagmaCube;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/MushroomCowController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/MushroomCowController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftMushroomCow;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHuman;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityMushroomCow;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EnumHand;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/OcelotController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/OcelotController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftOcelot;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityOcelot;
 import net.minecraft.server.v1_15_R1.EntityPose;
 import net.minecraft.server.v1_15_R1.EntityTypes;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PandaController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PandaController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPanda;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPanda;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ParrotController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ParrotController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftParrot;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHuman;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityParrot;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EnumHand;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PhantomController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PhantomController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPhantom;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.ControllerMove;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPhantom;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EnumDifficulty;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PigController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PigController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPig;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityLightning;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPig;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PigZombieController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PigZombieController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPigZombie;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPigZombie;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PillagerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PillagerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPillager;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPillager;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PolarBearController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PolarBearController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPolarBear;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPolarBear;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PufferFishController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/PufferFishController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftPufferFish;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.ControllerMove;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityPose;
 import net.minecraft.server.v1_15_R1.EntityPufferFish;
 import net.minecraft.server.v1_15_R1.EntitySize;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/RabbitController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/RabbitController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftRabbit;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityLiving;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityRabbit;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/RavagerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/RavagerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftRavager;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityRavager;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SalmonController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SalmonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSalmon;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.ControllerMove;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySalmon;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SheepController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SheepController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSheep;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySheep;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ShulkerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ShulkerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftShulker;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityAIBodyControl;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityShulker;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SilverfishController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SilverfishController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSilverfish;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySilverfish;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SkeletonController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SkeletonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSkeleton;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySkeleton;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SkeletonStrayController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SkeletonStrayController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftStray;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySkeletonStray;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SkeletonWitherController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SkeletonWitherController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftWitherSkeleton;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySkeletonWither;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SlimeController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SlimeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSlime;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHuman;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySlime;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SnowmanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SnowmanController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSnowman;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySnowman;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.GameRules;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SpiderController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SpiderController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSpider;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySpider;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SquidController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/SquidController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftSquid;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntitySquid;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/TraderLlamaController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/TraderLlamaController.java
@@ -3,7 +3,6 @@ package net.citizensnpcs.nms.v1_15_R1.entity;
 import java.lang.invoke.MethodHandle;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -26,6 +25,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityLlamaTrader;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/TropicalFishController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/TropicalFishController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftTropicalFish;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_15_R1.ControllerMove;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTropicalFish;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/TurtleController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/TurtleController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftTurtle;
@@ -23,6 +22,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityInsentient;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTurtle;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/VexController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/VexController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftVex;
@@ -18,6 +17,7 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityVex;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/VillagerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/VillagerController.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.TreeMap;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftVillager;
@@ -26,6 +25,7 @@ import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHuman;
 import net.minecraft.server.v1_15_R1.EntityLightning;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityVillager;
 import net.minecraft.server.v1_15_R1.EnumHand;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/VindicatorController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/VindicatorController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftVindicator;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityVindicator;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WanderingTraderController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WanderingTraderController.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.TreeMap;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftWanderingTrader;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityHuman;
 import net.minecraft.server.v1_15_R1.EntityLightning;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityVillagerTrader;
 import net.minecraft.server.v1_15_R1.EnumHand;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WitchController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WitchController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftWitch;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityWitch;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WitherController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WitherController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftWither;
@@ -18,6 +17,7 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityWither;
 import net.minecraft.server.v1_15_R1.NBTTagCompound;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WolfController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/WolfController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftWolf;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_15_R1.DataWatcherObject;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
 import net.minecraft.server.v1_15_R1.EntityLiving;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityWolf;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ZombieController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ZombieController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftZombie;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityZombie;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ZombieHuskController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ZombieHuskController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftHusk;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityZombieHusk;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ZombieVillagerController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/ZombieVillagerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_15_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftVillagerZombie;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_15_R1.BlockPosition;
 import net.minecraft.server.v1_15_R1.DamageSource;
 import net.minecraft.server.v1_15_R1.Entity;
 import net.minecraft.server.v1_15_R1.EntityBoat;
+import net.minecraft.server.v1_15_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_15_R1.EntityTypes;
 import net.minecraft.server.v1_15_R1.EntityZombieVillager;
 import net.minecraft.server.v1_15_R1.IBlockData;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/AreaEffectCloudController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/AreaEffectCloudController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftAreaEffectCloud;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ArmorStandController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ArmorStandController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftArmorStand;
@@ -14,6 +11,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EnderCrystalController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EnderCrystalController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEnderCrystal;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EnderPearlController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EnderPearlController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEnderPearl;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EnderSignalController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EnderSignalController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEnderSignal;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EvokerFangsController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/EvokerFangsController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -14,6 +11,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ExperienceOrbController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ExperienceOrbController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/FireworkController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/FireworkController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/FishingHookController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/FishingHookController.java
@@ -2,9 +2,6 @@ package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
 import java.util.UUID;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -16,6 +13,8 @@ import com.mojang.authlib.GameProfile;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.NMS;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ItemFrameController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ItemFrameController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -17,6 +14,8 @@ import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/LeashController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/LeashController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/PaintingController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/PaintingController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ShulkerBulletController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ShulkerBulletController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/SmallFireballController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/SmallFireballController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/SnowballController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/SnowballController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/SpectralArrowController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/SpectralArrowController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftArrow;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/TNTPrimedController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/TNTPrimedController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ThrownExpBottleController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ThrownExpBottleController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ThrownPotionController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ThrownPotionController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ThrownTridentController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/ThrownTridentController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/WitherSkullController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/nonliving/WitherSkullController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_15_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_15_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_15_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_15_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/network/EmptyNetworkManager.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/network/EmptyNetworkManager.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.nms.v1_15_R1.network;
 
 import java.io.IOException;
 
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.citizensnpcs.nms.v1_15_R1.util.NMSImpl;
 import net.minecraft.server.v1_15_R1.EnumProtocolDirection;
@@ -20,6 +21,6 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet, GenericFutureListener genericfuturelistener) {
+    public void sendPacket(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
     }
 }

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
@@ -305,7 +305,7 @@ public class NMSImpl implements NMSBridge {
         if (remove) {
             handle.world.getPlayers().remove(handle);
         } else if (!handle.world.getPlayers().contains(handle)) {
-            ((List) handle.world.getPlayers()).add(handle);
+            ((WorldServer) handle.world).getPlayers().add(handle);
         }
         // PlayerUpdateTask.addOrRemove(entity, remove);
     }
@@ -1236,8 +1236,7 @@ public class NMSImpl implements NMSBridge {
                 return true;
             } else if (!removeFromPlayerList) {
                 if (!entity.world.getPlayers().contains(entity)) {
-                    List list = entity.world.getPlayers();
-                    list.add(entity);
+                    ((WorldServer) entity.world).getPlayers().add((EntityPlayer) entity);
                 }
                 return true;
             } else {

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
@@ -1710,7 +1710,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerNavigation.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerNavigation.java
@@ -216,7 +216,7 @@ public class PlayerNavigation extends NavigationAbstract {
     }
 
     @Override
-    protected PathEntity a(Set var0, int var1, boolean var2, int var3) {
+    protected PathEntity a(Set<BlockPosition> var0, int var1, boolean var2, int var3) {
         if (var0.isEmpty()) {
             return null;
         } else if (this.a.locY() < 0.0D) {
@@ -243,8 +243,8 @@ public class PlayerNavigation extends NavigationAbstract {
     }
 
     @Override
-    public PathEntity a(Stream var0, int var1) {
-        return this.a((Set) var0.collect(Collectors.toSet()), 8, false, var1);
+    public PathEntity a(Stream<BlockPosition> var0, int var1) {
+        return this.a(var0.collect(Collectors.toSet()), 8, false, var1);
     }
 
     @Override
@@ -362,7 +362,7 @@ public class PlayerNavigation extends NavigationAbstract {
 
     private boolean b(int var0, int var1, int var2, int var3, int var4, int var5, Vec3D var6, double var7,
             double var9) {
-        Iterator var12 = BlockPosition.a(new BlockPosition(var0, var1, var2),
+        Iterator<BlockPosition> var12 = BlockPosition.a(new BlockPosition(var0, var1, var2),
                 new BlockPosition(var0 + var3 - 1, var1 + var4 - 1, var2 + var5 - 1)).iterator();
 
         double var13;
@@ -373,7 +373,7 @@ public class PlayerNavigation extends NavigationAbstract {
                 return true;
             }
 
-            var11 = (BlockPosition) var12.next();
+            var11 = var12.next();
             var13 = var11.getX() + 0.5D - var6.x;
             var15 = var11.getZ() + 0.5D - var6.z;
         } while (var13 * var7 + var15 * var9 < 0.0D || this.b.getType(var11).a(this.b, var11, PathMode.LAND));

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerPathfinder.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerPathfinder.java
@@ -26,6 +26,7 @@ import net.minecraft.server.v1_15_R1.Pathfinder;
 
 public class PlayerPathfinder extends Pathfinder {
     private final Path a = new Path();
+    @SuppressWarnings("rawtypes")
     private final Set b = Sets.newHashSet();
     private final PathPoint[] c = new PathPoint[32];
     private final int d;
@@ -65,7 +66,7 @@ public class PlayerPathfinder extends Pathfinder {
     }
 
     private PathEntity a(PathPoint var0, BlockPosition var1, boolean var2) {
-        List var3 = Lists.newArrayList();
+        List<PathPoint> var3 = Lists.newArrayList();
         PathPoint var4 = var0;
         var3.add(0, var0);
 
@@ -125,7 +126,7 @@ public class PlayerPathfinder extends Pathfinder {
             }
         }
 
-        Stream var8;
+        Stream<PathEntity> var8;
         if (var5.stream().anyMatch(PathDestination::f)) {
             var8 = var5.stream().filter(PathDestination::f).map((var1x) -> {
                 return this.a(var1x.d(), var1.get(var1x), true);
@@ -134,21 +135,21 @@ public class PlayerPathfinder extends Pathfinder {
             var8 = getFallbackDestinations(var1, var5);
         }
 
-        Optional var9 = var8.findFirst();
+        Optional<PathEntity> var9 = var8.findFirst();
         if (!var9.isPresent()) {
             return null;
         } else {
-            PathEntity var10 = (PathEntity) var9.get();
+            PathEntity var10 = var9.get();
             return var10;
         }
     }
 
-    private float a(PathPoint var0, Set var1) {
+    private float a(PathPoint var0, Set<PathDestination> var1) {
         float var2 = Float.MAX_VALUE;
 
         float var5;
-        for (Iterator var4 = var1.iterator(); var4.hasNext(); var2 = Math.min(var5, var2)) {
-            PathDestination var6 = (PathDestination) var4.next();
+        for (Iterator<PathDestination> var4 = var1.iterator(); var4.hasNext(); var2 = Math.min(var5, var2)) {
+            PathDestination var6 = var4.next();
             var5 = var0.a(var6);
             var6.a(var5, var0);
         }

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerPathfinderAbstract.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerPathfinderAbstract.java
@@ -12,7 +12,7 @@ import net.minecraft.server.v1_15_R1.PathfinderAbstract;
 public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
     protected ChunkCache a;
     protected EntityHumanNPC b;
-    protected final Int2ObjectMap c = new Int2ObjectOpenHashMap();
+    protected final Int2ObjectMap<PathPoint> c = new Int2ObjectOpenHashMap<>();
     protected int d;
     protected int e;
     protected int f;
@@ -42,7 +42,7 @@ public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
 
     @Override
     protected PathPoint a(int var0, int var1, int var2) {
-        return (PathPoint) this.c.computeIfAbsent(PathPoint.b(var0, var1, var2), (var3) -> {
+        return this.c.computeIfAbsent(PathPoint.b(var0, var1, var2), (var3) -> {
             return new PathPoint(var0, var1, var2);
         });
     }

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/BatController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/BatController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftBat;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBat;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;
 import net.minecraft.server.v1_16_R1.SoundEffect;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/BeeController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/BeeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftBee;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBee;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;
 import net.minecraft.server.v1_16_R1.SoundEffect;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/BlazeController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/BlazeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftBlaze;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBlaze;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;
 import net.minecraft.server.v1_16_R1.SoundEffect;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CatController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CatController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftCat;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityCat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CaveSpiderController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CaveSpiderController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftCaveSpider;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityCaveSpider;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ChickenController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ChickenController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftChicken;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityChicken;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CodController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CodController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftCod;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityCod;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CreeperController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/CreeperController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftCreeper;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityCreeper;
 import net.minecraft.server.v1_16_R1.EntityLightning;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/DrownedController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/DrownedController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftDrowned;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityDrowned;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EnderDragonController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EnderDragonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEnderDragon;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityEnderDragon;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;
 import net.minecraft.server.v1_16_R1.SoundEffect;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EndermanController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EndermanController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEnderman;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityEnderman;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EndermiteController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EndermiteController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEndermite;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityEndermite;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EntityHumanNPC.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EntityHumanNPC.java
@@ -492,7 +492,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         Packet<?>[] packets = new Packet[1];
         List<Pair<EnumItemSlot, ItemStack>> vals = Lists.newArrayList();
         for (EnumItemSlot slot : EnumItemSlot.values()) {
-            vals.add(new Pair<EnumItemSlot, ItemStack>(slot, getEquipment(slot)));
+            vals.add(new Pair<>(slot, getEquipment(slot)));
         }
         packets[0] = new PacketPlayOutEntityEquipment(getId(), vals);
         NMSImpl.sendPacketsNearby(getBukkitEntity(), current, packets);

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EvokerController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/EvokerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEvoker;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityEvoker;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/FoxController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/FoxController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftFox;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityFox;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GhastController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GhastController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftGhast;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityGhast;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;
 import net.minecraft.server.v1_16_R1.SoundEffect;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GiantController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GiantController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftGiant;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityGiantZombie;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GuardianController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GuardianController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftGuardian;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityGuardian;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GuardianElderController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/GuardianElderController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftElderGuardian;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityGuardianElder;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHorse;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.GenericAttributes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseDonkeyController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseDonkeyController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftDonkey;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHorseDonkey;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.GenericAttributes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseMuleController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseMuleController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHorseMule;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.GenericAttributes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseSkeletonController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseSkeletonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHorseSkeleton;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.GenericAttributes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseZombieController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/HorseZombieController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -25,6 +24,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHorseZombie;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.GenericAttributes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/IllusionerController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/IllusionerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftIllusioner;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityIllagerIllusioner;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/IronGolemController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/IronGolemController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftIronGolem;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityIronGolem;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/LlamaController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/LlamaController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -24,6 +23,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityLlama;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/MagmaCubeController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/MagmaCubeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftMagmaCube;
@@ -23,6 +22,7 @@ import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHuman;
 import net.minecraft.server.v1_16_R1.EntityMagmaCube;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/OcelotController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/OcelotController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftOcelot;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityOcelot;
 import net.minecraft.server.v1_16_R1.EntityPose;
 import net.minecraft.server.v1_16_R1.EntityTypes;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PandaController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PandaController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPanda;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityPanda;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PigController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PigController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPig;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityLightning;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityPig;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PigZombieController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PigZombieController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPigZombie;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityPigZombie;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PillagerController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PillagerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPillager;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityPillager;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PolarBearController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PolarBearController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPolarBear;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityPolarBear;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PufferFishController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/PufferFishController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftPufferFish;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_16_R1.ControllerMove;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityPose;
 import net.minecraft.server.v1_16_R1.EntityPufferFish;
 import net.minecraft.server.v1_16_R1.EntitySize;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/RabbitController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/RabbitController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftRabbit;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityLiving;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityRabbit;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/RavagerController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/RavagerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftRavager;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityRavager;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SalmonController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SalmonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSalmon;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.ControllerMove;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySalmon;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SheepController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SheepController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSheep;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySheep;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SilverfishController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SilverfishController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSilverfish;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySilverfish;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SkeletonController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SkeletonController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSkeleton;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySkeleton;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SkeletonStrayController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SkeletonStrayController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftStray;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySkeletonStray;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SkeletonWitherController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SkeletonWitherController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftWitherSkeleton;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySkeletonWither;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SlimeController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SlimeController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSlime;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityHuman;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySlime;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SnowmanController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SnowmanController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSnowman;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySnowman;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.GameRules;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SpiderController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SpiderController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSpider;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySpider;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SquidController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/SquidController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftSquid;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntitySquid;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/TraderLlamaController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/TraderLlamaController.java
@@ -3,7 +3,6 @@ package net.citizensnpcs.nms.v1_16_R1.entity;
 import java.lang.invoke.MethodHandle;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -26,6 +25,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityLlamaTrader;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/TropicalFishController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/TropicalFishController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftTropicalFish;
@@ -21,6 +20,7 @@ import net.minecraft.server.v1_16_R1.ControllerMove;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTropicalFish;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/VexController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/VexController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftVex;
@@ -18,6 +17,7 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityVex;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/VindicatorController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/VindicatorController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftVindicator;
@@ -20,6 +19,7 @@ import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityVindicator;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/WitchController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/WitchController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftWitch;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityWitch;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/WitherController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/WitherController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftWither;
@@ -18,6 +17,7 @@ import net.citizensnpcs.util.Util;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityWither;
 import net.minecraft.server.v1_16_R1.NBTTagCompound;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/WolfController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/WolfController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftWolf;
@@ -22,6 +21,7 @@ import net.minecraft.server.v1_16_R1.DataWatcherObject;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
 import net.minecraft.server.v1_16_R1.EntityLiving;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityWolf;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ZombieController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ZombieController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftZombie;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityZombie;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ZombieHuskController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ZombieHuskController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftHusk;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityZombieHusk;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ZombieVillagerController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/ZombieVillagerController.java
@@ -1,7 +1,6 @@
 package net.citizensnpcs.nms.v1_16_R1.entity;
 
 import org.bukkit.Bukkit;
-import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftVillagerZombie;
@@ -19,6 +18,7 @@ import net.minecraft.server.v1_16_R1.BlockPosition;
 import net.minecraft.server.v1_16_R1.DamageSource;
 import net.minecraft.server.v1_16_R1.Entity;
 import net.minecraft.server.v1_16_R1.EntityBoat;
+import net.minecraft.server.v1_16_R1.EntityMinecartAbstract;
 import net.minecraft.server.v1_16_R1.EntityTypes;
 import net.minecraft.server.v1_16_R1.EntityZombieVillager;
 import net.minecraft.server.v1_16_R1.IBlockData;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/AreaEffectCloudController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/AreaEffectCloudController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftAreaEffectCloud;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/EnderCrystalController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/EnderCrystalController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEnderCrystal;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/EnderPearlController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/EnderPearlController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEnderPearl;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/EnderSignalController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/EnderSignalController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEnderSignal;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ExperienceOrbController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ExperienceOrbController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/FireworkController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/FireworkController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ItemFrameController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ItemFrameController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -17,6 +14,8 @@ import net.citizensnpcs.api.event.DespawnReason;
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/LeashController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/LeashController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/PaintingController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/PaintingController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ShulkerBulletController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ShulkerBulletController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/SmallFireballController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/SmallFireballController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/SnowballController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/SnowballController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/SpectralArrowController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/SpectralArrowController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftArrow;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/TNTPrimedController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/TNTPrimedController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ThrownExpBottleController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ThrownExpBottleController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ThrownPotionController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ThrownPotionController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ThrownTridentController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/ThrownTridentController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/WitherSkullController.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/entity/nonliving/WitherSkullController.java
@@ -1,8 +1,5 @@
 package net.citizensnpcs.nms.v1_16_R1.entity.nonliving;
 
-import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
-import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
-
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_16_R1.entity.CraftEntity;
@@ -12,6 +9,8 @@ import org.bukkit.util.Vector;
 
 import net.citizensnpcs.api.event.NPCPushEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.nms.v1_16_R1.entity.MobEntityController;
+import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.citizensnpcs.npc.CitizensNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.Util;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/network/EmptyNetworkManager.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/network/EmptyNetworkManager.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.nms.v1_16_R1.network;
 
 import java.io.IOException;
 
+import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import net.citizensnpcs.nms.v1_16_R1.util.NMSImpl;
 import net.minecraft.server.v1_16_R1.EnumProtocolDirection;
@@ -20,6 +21,6 @@ public class EmptyNetworkManager extends NetworkManager {
     }
 
     @Override
-    public void sendPacket(Packet packet, GenericFutureListener genericfuturelistener) {
+    public void sendPacket(Packet<?> packet, GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
     }
 }

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/NMSImpl.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/NMSImpl.java
@@ -1663,7 +1663,7 @@ public class NMSImpl implements NMSBridge {
     }
 
     public static void sendPacketNearby(Player from, Location location, Packet<?> packet, double radius) {
-        List<Packet<?>> list = new ArrayList<Packet<?>>();
+        List<Packet<?>> list = new ArrayList<>();
         list.add(packet);
         sendPacketsNearby(from, location, list, radius);
     }

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/NMSImpl.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/NMSImpl.java
@@ -310,7 +310,7 @@ public class NMSImpl implements NMSBridge {
         if (remove) {
             handle.world.getPlayers().remove(handle);
         } else if (!handle.world.getPlayers().contains(handle)) {
-            ((List) handle.world.getPlayers()).add(handle);
+            ((WorldServer) handle.world).getPlayers().add(handle);
         }
         // PlayerUpdateTask.addOrRemove(entity, remove);
     }
@@ -1251,8 +1251,7 @@ public class NMSImpl implements NMSBridge {
                 return true;
             } else if (!removeFromPlayerList) {
                 if (!entity.world.getPlayers().contains(entity)) {
-                    List list = entity.world.getPlayers();
-                    list.add(entity);
+                    ((WorldServer) entity.world).getPlayers().add((EntityPlayer) entity);
                 }
                 return true;
             } else {

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/PlayerPathfinder.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/PlayerPathfinder.java
@@ -10,7 +10,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
@@ -42,7 +41,7 @@ public class PlayerPathfinder extends Pathfinder {
         this.d.a();
         this.c.a(var0, var1);
         PathPoint var6 = this.c.b();
-        Map var7 = var2.stream().collect(Collectors.toMap((var0x) -> {
+        Map<PathDestination, BlockPosition> var7 = var2.stream().collect(Collectors.toMap((var0x) -> {
             return this.c.a((double) var0x.getX(), (double) var0x.getY(), (double) var0x.getZ());
         }, Function.identity()));
         PathEntity var8 = this.a(var6, var7, var3, var4, var5);
@@ -56,7 +55,7 @@ public class PlayerPathfinder extends Pathfinder {
         this.d.a();
         this.c.a(var0, var1);
         PathPoint var6 = this.c.b();
-        Map var7 = var2.stream().collect(Collectors.toMap((var0x) -> {
+        Map<PathDestination, BlockPosition> var7 = var2.stream().collect(Collectors.toMap((var0x) -> {
             return this.c.a((double) var0x.getX(), (double) var0x.getY(), (double) var0x.getZ());
         }, Function.identity()));
         PathEntity var8 = this.a(var6, var7, var3, var4, var5);
@@ -65,7 +64,7 @@ public class PlayerPathfinder extends Pathfinder {
     }
 
     private PathEntity a(PathPoint var0, BlockPosition var1, boolean var2) {
-        List var3 = Lists.newArrayList();
+        List<PathPoint> var3 = Lists.newArrayList();
         PathPoint var4 = var0;
         var3.add(0, var0);
 
@@ -77,14 +76,13 @@ public class PlayerPathfinder extends Pathfinder {
         return new PathEntity(var3, var1, var2);
     }
 
-    private PathEntity a(PathPoint var0, Map var1, float var2, int var3, float var4) {
-        Set var5 = var1.keySet();
+    private PathEntity a(PathPoint var0, Map<PathDestination, BlockPosition> var1, float var2, int var3, float var4) {
+        Set<PathDestination> var5 = var1.keySet();
         var0.e = 0.0F;
         var0.f = this.a(var0, var5);
         var0.g = var0.f;
         this.d.a();
         this.d.a(var0);
-        Set var6 = ImmutableSet.of();
         int var7 = 0;
         Set<PathDestination> var8 = Sets.newHashSetWithExpectedSize(var5.size());
         int var9 = (int) (this.b * var4);
@@ -97,10 +95,10 @@ public class PlayerPathfinder extends Pathfinder {
 
             PathPoint var10 = this.d.c();
             var10.i = true;
-            Iterator var12 = var5.iterator();
+            Iterator<PathDestination> var12 = var5.iterator();
 
             while (var12.hasNext()) {
-                PathDestination var122 = (PathDestination) var12.next();
+                PathDestination var122 = var12.next();
                 if (var10.c(var122) <= var3) {
                     var122.e();
                     var8.add(var122);
@@ -133,23 +131,23 @@ public class PlayerPathfinder extends Pathfinder {
                 }
             }
         }
-        Optional var10 = !var8.isEmpty() ? var8.stream().map((var1x) -> {
-            return this.a(var1x.d(), (BlockPosition) var1.get(var1x), true);
+        Optional<PathEntity> var10 = !var8.isEmpty() ? var8.stream().map((var1x) -> {
+            return this.a(var1x.d(), var1.get(var1x), true);
         }).min(Comparator.comparingInt(PathEntity::e)) : getFallbackDestinations(var1, var5).findFirst();
         if (!var10.isPresent()) {
             return null;
         } else {
-            PathEntity var11 = (PathEntity) var10.get();
+            PathEntity var11 = var10.get();
             return var11;
         }
     }
 
-    private float a(PathPoint var0, Set var1) {
+    private float a(PathPoint var0, Set<PathDestination> var1) {
         float var2 = Float.MAX_VALUE;
 
         float var5;
-        for (Iterator var4 = var1.iterator(); var4.hasNext(); var2 = Math.min(var5, var2)) {
-            PathDestination var44 = (PathDestination) var4.next();
+        for (Iterator<PathDestination> var4 = var1.iterator(); var4.hasNext(); var2 = Math.min(var5, var2)) {
+            PathDestination var44 = var4.next();
             var5 = var0.a(var44);
             var44.a(var5, var0);
         }

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/PlayerPathfinderAbstract.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/PlayerPathfinderAbstract.java
@@ -13,7 +13,7 @@ import net.minecraft.server.v1_16_R1.PathfinderAbstract;
 public abstract class PlayerPathfinderAbstract extends PathfinderAbstract {
     protected ChunkCache a;
     protected EntityHumanNPC b;
-    protected final Int2ObjectMap<PathPoint> c = new Int2ObjectOpenHashMap();
+    protected final Int2ObjectMap<PathPoint> c = new Int2ObjectOpenHashMap<>();
     protected int d;
     protected int e;
     protected int f;

--- a/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/PlayerPathfinderNormal.java
+++ b/v1_16_R1/src/main/java/net/citizensnpcs/nms/v1_16_R1/util/PlayerPathfinderNormal.java
@@ -38,8 +38,8 @@ import net.minecraft.server.v1_16_R1.VoxelShape;
 public class PlayerPathfinderNormal extends PlayerPathfinderAbstract {
     protected float j;
 
-    private final Long2ObjectMap<PathType> k = new Long2ObjectOpenHashMap();
-    private final Object2BooleanMap<AxisAlignedBB> l = new Object2BooleanOpenHashMap();
+    private final Long2ObjectMap<PathType> k = new Long2ObjectOpenHashMap<>();
+    private final Object2BooleanMap<AxisAlignedBB> l = new Object2BooleanOpenHashMap<>();
 
     @Override
     public void a() {

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/network/EmptyNetHandler.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/network/EmptyNetHandler.java
@@ -12,6 +12,6 @@ public class EmptyNetHandler extends PlayerConnection {
     }
 
     @Override
-    public void sendPacket(Packet packet) {
+    public void sendPacket(@SuppressWarnings("rawtypes") Packet packet) {
     }
 }


### PR DESCRIPTION
This request consists of three types of fixes for compiler warnings / infos:
1. Removed unused import
2. Removed redundant type arguments using the diamond operator
3. Added explicit type arguments to avoid "raw types"