### PR TITLE
Patch consistent application of scoreboard teams

### DIFF
--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -73,6 +73,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -44,6 +40,11 @@ public class HumanController extends AbstractEntityController {
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -73,6 +73,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -44,6 +40,11 @@ public class HumanController extends AbstractEntityController {
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -73,6 +73,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -44,6 +40,11 @@ public class HumanController extends AbstractEntityController {
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -73,6 +73,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -44,6 +40,11 @@ public class HumanController extends AbstractEntityController {
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -73,6 +73,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -44,6 +40,11 @@ public class HumanController extends AbstractEntityController {
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -73,6 +73,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -44,6 +40,11 @@ public class HumanController extends AbstractEntityController {
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;

--- a/v1_16_R2/src/main/java/net/citizensnpcs/nms/v1_16_R2/entity/HumanController.java
+++ b/v1_16_R2/src/main/java/net/citizensnpcs/nms/v1_16_R2/entity/HumanController.java
@@ -74,6 +74,9 @@ public class HumanController extends AbstractEntityController {
                 int mode = 2;
                 if (team == null) {
                     team = scoreboard.registerNewTeam(teamName);
+                    if (npc.requiresNameHologram()) {
+                        team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
+                    }
                     mode = 0;
                 }
                 team.addPlayer(handle.getBukkitEntity());

--- a/v1_16_R2/src/main/java/net/citizensnpcs/nms/v1_16_R2/entity/HumanController.java
+++ b/v1_16_R2/src/main/java/net/citizensnpcs/nms/v1_16_R2/entity/HumanController.java
@@ -33,10 +33,6 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
 
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
@@ -45,6 +41,12 @@ public class HumanController extends AbstractEntityController {
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
         }
+
+        String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -67,7 +69,6 @@ public class HumanController extends AbstractEntityController {
                 if (!Setting.USE_SCOREBOARD_TEAMS.asBoolean())
                     return;
                 Scoreboard scoreboard = Util.getDummyScoreboard();
-                String teamName = Util.getTeamName(profile.getId());
 
                 Team team = scoreboard.getTeam(teamName);
                 int mode = 2;

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -7,6 +7,7 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.NameTagVisibility;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
@@ -73,6 +74,9 @@ public class HumanController extends AbstractEntityController {
                     int mode = 2;
                     if (team == null) {
                         team = scoreboard.registerNewTeam(teamName);
+                        if (npc.requiresNameHologram()) {
+                            team.setNameTagVisibility(NameTagVisibility.NEVER);
+                        }
                         mode = 0;
                     }
                     team.addPlayer(handle.getBukkitEntity());

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -33,17 +33,18 @@ public class HumanController extends AbstractEntityController {
         final WorldServer nmsWorld = ((CraftWorld) at.getWorld()).getHandle();
         String coloredName = npc.getFullName();
         String name = coloredName.length() > 16 ? coloredName.substring(0, 16) : coloredName;
-        if (npc.requiresNameHologram()) {
-            name = npc.getId() + UUID.randomUUID().toString().replace("-", "");
-            name = name.substring(0, 16);
-        }
-        
+
         UUID uuid = npc.getUniqueId();
         if (uuid.version() == 4) { // clear version
             long msb = uuid.getMostSignificantBits();
             msb &= ~0x0000000000004000L;
             msb |= 0x0000000000002000L;
             uuid = new UUID(msb, uuid.getLeastSignificantBits());
+        }
+
+        final String teamName = Util.getTeamName(uuid);
+        if (npc.requiresNameHologram()) {
+            name = teamName;
         }
 
         final GameProfile profile = new GameProfile(uuid, name);
@@ -67,7 +68,6 @@ public class HumanController extends AbstractEntityController {
 
                 if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
                     Scoreboard scoreboard = Util.getDummyScoreboard();
-                    String teamName = Util.getTeamName(profile.getId());
 
                     Team team = scoreboard.getTeam(teamName);
                     int mode = 2;


### PR DESCRIPTION
This corrects issues with scoreboard team logic failing to apply in some cases by ensuring NPCs use a consistent internal entity name, rather than randomizing.

The original issue was reported by Robin as an issue affecting LeaderHeads. It was a long-name hologram appearing simultaneously with the raw NPC entity generated name (which under normal circumstances is automatically hidden by a scoreboard team packet).

The issue was demonstrated with Java code, however I was also able to quickly replicate it with this short Denizen script:

```yml
test:
    type: task
    script:
    - despawn <npc>
    - adjust <npc> skin:steve
    - rename joewithquitealongnamehere
    - spawn <npc> <npc.location>
```

The issue appeared to be primarily related to the simultaneous application of a name and a skin, but generally relates to the respawn sequence and handling of scoreboard teams. Specifically, scoreboard teams not applying to the NPC after it respawns in some circumstances.

The fundamental issue appears to be that the scoreboard team logic was written with the assumption that the NPC entity name would not change, however commit https://github.com/CitizensDev/Citizens2/commit/0a4905c0f30b24ed2fb544a42712212f5a348628 applied randomization. This was done in response to my Discord post here, regarding issues with multiple NPCs having the same names:

```
mcmonkey07/07/2020
@fullwall if we're intentionally systematically hiding the names
we can bypass that problem actually
by way of just... giving unique names to the NPC
since the names are hidden
the name attached to the human entity is what's used to match scoreboards
we can just make it generated random text instead of the actual player-given name
which will solve that problem straight away, albeit I'm not sure what side effects might arise
(ie when might the generated name be visible)
actually not random text, just make it like npc_<id> or sommin
```

It appears that the "actually not random text" part got missed when making the commit. This PR corrects the code accordingly (ie, it no longer generates random text, and instead uses the same snipped NPC UUID that's already in used for the scoreboard team name).

In testing, the script is no longer able to reproduce the issue. A rather minimal attempt at re-testing past issues for risk of reintroducing them hasn't found anything.

All testing has been done on Spigot 1.16.2, but code has been backported to all other modules on the assumption of logical consistency. The relevant code in other modules is all the same with the exception of the 1.8 module which is configured to obey an older Java compiler standard and so the `final` keyword was needed.

**EDIT:** While testing, I noticed that the name tag visibility was being set true in the initial packet, and false later in follow up packets. I added a commit that makes sure it's set false from the start when required. The effect of this result is just the placeholder name being less visible while spawning, but might also help keep it hidden better.