### PR TITLE
Add NMS repo to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,23 @@
 	<groupId>net.citizensnpcs</groupId>
 	<artifactId>citizens-parent</artifactId>
 	<version>2.0.27-SNAPSHOT</version>
+	
 	<properties>
 		<BUILD_NUMBER>Unknown</BUILD_NUMBER>
 		<CITIZENS_VERSION>2.0.27</CITIZENS_VERSION>
 	</properties>
+	
+	<repositories>
+		<repository>
+			<id>nms-repo</id>
+			<url>https://repo.codemc.io/repository/nms/</url>
+		</repository>
+	</repositories>
+	
 	<build>
 		<defaultGoal>clean package install</defaultGoal>
 	</build>
+	
 	<modules>
 		<module>main</module>
 		<module>v1_8_R3</module>


### PR DESCRIPTION
Currently, it's not present in the POM file a Maven Repository containing the Spigot NMS Artifacts, requiring every person building the plugin to have all the server jars(each one weighing several MBs) already stored in the local repo, else the build will fail.
I added the CodeMC [NMS Repository](https://docs.codemc.io/faq/#what-is-the-nms-maven-repository) to the main POM file, tested the build with a clean repo and it can now build without problems even from a clean system.