### PR TITLE
Fix llamas not being controllable with '/npc controllable'

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/Controllable.java
+++ b/main/src/main/java/net/citizensnpcs/trait/Controllable.java
@@ -318,7 +318,7 @@ public class Controllable extends Trait implements Toggleable, CommandConfigurab
             boolean onGround = NMS.isOnGround(npc.getEntity());
             float speedMod = npc.getNavigator().getDefaultParameters()
                     .modifiedSpeed((onGround ? GROUND_SPEED : AIR_SPEED));
-            if (!Util.isHorse(npc.getEntity().getType())) {
+            if (!Util.isHorse(npc.getEntity().getType()) || npc.getEntity().getType().name().equals("LLAMA") || npc.getEntity().getType().name().equals("TRADER_LLAMA")) {
                 // just use minecraft horse physics
                 speed = updateHorizontalSpeed(npc.getEntity(), rider, speed, speedMod);
             }


### PR DESCRIPTION
Llamas are looped in with horses for certain traits (such as having an inventory) but not in movement. This commit excludes llamas from the `updateHorizontalSpeed` check as they cannot be controlled in vanilla.

Tested with 1.12.2 and 1.16.4. Fixes #2390.