### PR TITLE
Fix realistic looking for trait lookclose

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/LookClose.java
+++ b/main/src/main/java/net/citizensnpcs/trait/LookClose.java
@@ -54,9 +54,14 @@ public class LookClose extends Trait implements Toggleable, CommandConfigurable 
      * is true.
      */
     public boolean canSeeTarget() {
-        return realisticLooking && npc.getEntity() instanceof LivingEntity
-                ? ((LivingEntity) npc.getEntity()).hasLineOfSight(lookingAt)
-                : lookingAt != null && lookingAt.isValid();
+        return canSeeTarget(lookingAt);
+    }
+
+    private boolean canSeeTarget(Player player) {
+        return !realisticLooking ||
+                (npc.getEntity() instanceof LivingEntity
+                        ? ((LivingEntity) npc.getEntity()).hasLineOfSight(player)
+                        : lookingAt != null);
     }
 
     @Override
@@ -120,7 +125,7 @@ public class LookClose extends Trait implements Toggleable, CommandConfigurable 
 
     private boolean isInvisible(Player player) {
         return player.getGameMode() == GameMode.SPECTATOR || player.hasPotionEffect(PotionEffectType.INVISIBILITY)
-                || isPluginVanished(player);
+                || isPluginVanished(player) || !canSeeTarget(player);
     }
 
     private boolean isPluginVanished(Player player) {
@@ -193,7 +198,7 @@ public class LookClose extends Trait implements Toggleable, CommandConfigurable 
             t = randomLookDelay;
         }
         t--;
-        if (lookingAt != null && canSeeTarget()) {
+        if (lookingAt != null) {
             Util.faceEntity(npc.getEntity(), lookingAt);
             if (npc.getEntity().getType().name().equals("SHULKER")) {
                 NMS.setPeekShulker(npc.getEntity(), 100 - (int) Math


### PR DESCRIPTION
The npc would select player out of line of sight, and not unselect them when the player goes out of line of sight. If a player was hiding out of sight a new player within line of sight would not be selected.

Closes #2454