### PR TITLE
Fix blank names for a few seconds after spawning an npc.

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -327,6 +327,7 @@ public class CitizensNPC extends AbstractNPC {
         }
 
         updateFlyableState();
+        updateCustomNameVisibility();
         updateCustomName();
 
         Messaging.debug("Spawned", getId(), "SpawnReason." + reason);
@@ -381,11 +382,7 @@ public class CitizensNPC extends AbstractNPC {
                 updateCounter = 0;
             }
 
-            String nameplateVisible = data().<Object> get(NPC.NAMEPLATE_VISIBLE_METADATA, true).toString();
-            if (requiresNameHologram()) {
-                nameplateVisible = "false";
-            }
-            getEntity().setCustomNameVisible(Boolean.parseBoolean(nameplateVisible));
+            updateCustomNameVisibility();
 
             if (isLiving) {
                 NMS.setKnockbackResistance((LivingEntity) getEntity(),
@@ -404,6 +401,14 @@ public class CitizensNPC extends AbstractNPC {
             Messaging.logTr(Messages.EXCEPTION_UPDATING_NPC, getId(), error.getMessage());
             error.printStackTrace();
         }
+    }
+
+    private void updateCustomNameVisibility() {
+        String nameplateVisible = data().<Object> get(NPC.NAMEPLATE_VISIBLE_METADATA, true).toString();
+        if (requiresNameHologram()) {
+            nameplateVisible = "false";
+        }
+        getEntity().setCustomNameVisible(Boolean.parseBoolean(nameplateVisible));
     }
 
     private void updateCustomName() {


### PR DESCRIPTION
On spawning NPCs `CitizensNPC#updateCustomName` checks if the entity's custom name is visible, if it isn't, it sets the entity's custom name to blank, however the custom name visibility is only updated when ticking, so it can take a few seconds to update to the NPC's correct name after it's spawned since the custom name is only updated every 30 ticks.

This is fixed by updating the entity custom name visibility before updating the entity's name on `CitizensNPC#spawn`.