### PR TITLE
Apply scoreboards instantly at spawn instead of with delay

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -52,7 +52,6 @@ import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.bukkit.scoreboard.Team;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.ArrayListMultimap;
@@ -433,24 +432,6 @@ public class EventListen implements Listener {
                     + event.getReason().name());
         }
         skinUpdateTracker.onNPCDespawn(event.getNPC());
-        if (!Setting.USE_SCOREBOARD_TEAMS.asBoolean())
-            return;
-        String teamName = event.getNPC().data().get(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, "");
-        if (teamName.isEmpty())
-            return;
-        Team team = Util.getDummyScoreboard().getTeam(teamName);
-        event.getNPC().data().remove(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA);
-        if (team == null || !(event.getNPC().getEntity() instanceof Player))
-            return;
-        Player player = (Player) event.getNPC().getEntity();
-        if (team.hasPlayer(player)) {
-            if (team.getSize() == 1) {
-                Util.sendTeamPacketToOnlinePlayers(team, 1);
-                team.unregister();
-            } else {
-                team.removePlayer(player);
-            }
-        }
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/HumanController.java
@@ -7,8 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_10_R1.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -47,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -66,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                    Team team = scoreboard.getTeam(teamName);
-                    int mode = 2;
-                    if (team == null) {
-                        team = scoreboard.registerNewTeam(teamName);
-                        if (npc.requiresNameHologram()) {
-                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
-                        }
-                        mode = 0;
-                    }
-                    team.addPlayer(handle.getBukkitEntity());
-
-                    handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                    Util.sendTeamPacketToOnlinePlayers(team, mode);
-                }
             }
         }, 20);
 
@@ -102,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -1037,16 +1037,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/HumanController.java
@@ -7,8 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_11_R1.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -47,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -66,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                    Team team = scoreboard.getTeam(teamName);
-                    int mode = 2;
-                    if (team == null) {
-                        team = scoreboard.registerNewTeam(teamName);
-                        if (npc.requiresNameHologram()) {
-                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
-                        }
-                        mode = 0;
-                    }
-                    team.addPlayer(handle.getBukkitEntity());
-
-                    handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                    Util.sendTeamPacketToOnlinePlayers(team, mode);
-                }
             }
         }, 20);
 
@@ -102,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -219,7 +219,6 @@ import net.minecraft.server.v1_11_R1.PathfinderGoalSelector;
 import net.minecraft.server.v1_11_R1.RegistryMaterials;
 import net.minecraft.server.v1_11_R1.ReportedException;
 import net.minecraft.server.v1_11_R1.ScoreboardTeam;
-import net.minecraft.server.v1_11_R1.ScoreboardTeamBase.EnumNameTagVisibility;
 import net.minecraft.server.v1_11_R1.SoundEffect;
 import net.minecraft.server.v1_11_R1.Vec3D;
 import net.minecraft.server.v1_11_R1.WorldServer;
@@ -1094,16 +1093,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/HumanController.java
@@ -7,8 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -47,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -66,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                    Team team = scoreboard.getTeam(teamName);
-                    int mode = 2;
-                    if (team == null) {
-                        team = scoreboard.registerNewTeam(teamName);
-                        if (npc.requiresNameHologram()) {
-                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
-                        }
-                        mode = 0;
-                    }
-                    team.addPlayer(handle.getBukkitEntity());
-
-                    handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                    Util.sendTeamPacketToOnlinePlayers(team, mode);
-                }
             }
         }, 20);
 
@@ -102,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -25,7 +25,6 @@ import org.bukkit.boss.BossBar;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.CraftSound;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
-import org.bukkit.craftbukkit.v1_12_R1.block.CraftBlock;
 import org.bukkit.craftbukkit.v1_12_R1.boss.CraftBossBar;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftEntity;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
@@ -224,7 +223,6 @@ import net.minecraft.server.v1_12_R1.PathfinderGoalSelector;
 import net.minecraft.server.v1_12_R1.RegistryMaterials;
 import net.minecraft.server.v1_12_R1.ReportedException;
 import net.minecraft.server.v1_12_R1.ScoreboardTeam;
-import net.minecraft.server.v1_12_R1.ScoreboardTeamBase.EnumNameTagVisibility;
 import net.minecraft.server.v1_12_R1.SoundEffect;
 import net.minecraft.server.v1_12_R1.SoundEffects;
 import net.minecraft.server.v1_12_R1.Vec3D;
@@ -1103,16 +1101,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -240,7 +240,6 @@ import net.minecraft.server.v1_13_R2.PathfinderGoalSelector;
 import net.minecraft.server.v1_13_R2.RegistryMaterials;
 import net.minecraft.server.v1_13_R2.ReportedException;
 import net.minecraft.server.v1_13_R2.ScoreboardTeam;
-import net.minecraft.server.v1_13_R2.ScoreboardTeamBase.EnumNameTagVisibility;
 import net.minecraft.server.v1_13_R2.SoundEffect;
 import net.minecraft.server.v1_13_R2.SoundEffects;
 import net.minecraft.server.v1_13_R2.Vec3D;
@@ -1140,16 +1139,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/HumanController.java
@@ -7,8 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_14_R1.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -47,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -66,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                    Team team = scoreboard.getTeam(teamName);
-                    int mode = 2;
-                    if (team == null) {
-                        team = scoreboard.registerNewTeam(teamName);
-                        if (npc.requiresNameHologram()) {
-                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
-                        }
-                        mode = 0;
-                    }
-                    team.addPlayer(handle.getBukkitEntity());
-
-                    handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                    Util.sendTeamPacketToOnlinePlayers(team, mode);
-                }
             }
         }, 20);
 
@@ -102,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
@@ -261,7 +261,6 @@ import net.minecraft.server.v1_14_R1.PlayerChunkMap.EntityTracker;
 import net.minecraft.server.v1_14_R1.RegistryBlocks;
 import net.minecraft.server.v1_14_R1.ReportedException;
 import net.minecraft.server.v1_14_R1.ScoreboardTeam;
-import net.minecraft.server.v1_14_R1.ScoreboardTeamBase.EnumNameTagVisibility;
 import net.minecraft.server.v1_14_R1.SoundEffect;
 import net.minecraft.server.v1_14_R1.Vec3D;
 import net.minecraft.server.v1_14_R1.VoxelShape;
@@ -1191,16 +1190,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/HumanController.java
@@ -7,8 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_15_R1.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -47,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -66,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                    Team team = scoreboard.getTeam(teamName);
-                    int mode = 2;
-                    if (team == null) {
-                        team = scoreboard.registerNewTeam(teamName);
-                        if (npc.requiresNameHologram()) {
-                            team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
-                        }
-                        mode = 0;
-                    }
-                    team.addPlayer(handle.getBukkitEntity());
-
-                    handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                    Util.sendTeamPacketToOnlinePlayers(team, mode);
-                }
             }
         }, 20);
 
@@ -102,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
@@ -264,7 +264,6 @@ import net.minecraft.server.v1_15_R1.PlayerChunkMap.EntityTracker;
 import net.minecraft.server.v1_15_R1.RegistryBlocks;
 import net.minecraft.server.v1_15_R1.ReportedException;
 import net.minecraft.server.v1_15_R1.ScoreboardTeam;
-import net.minecraft.server.v1_15_R1.ScoreboardTeamBase.EnumNameTagVisibility;
 import net.minecraft.server.v1_15_R1.SoundEffect;
 import net.minecraft.server.v1_15_R1.Vec3D;
 import net.minecraft.server.v1_15_R1.VoxelShape;
@@ -1209,16 +1208,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/HumanController.java
+++ b/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/HumanController.java
@@ -7,8 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -47,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -66,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (!Setting.USE_SCOREBOARD_TEAMS.asBoolean())
-                    return;
-                Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                Team team = scoreboard.getTeam(teamName);
-                int mode = 2;
-                if (team == null) {
-                    team = scoreboard.registerNewTeam(teamName);
-                    if (npc.requiresNameHologram()) {
-                        team.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.NEVER);
-                    }
-                    mode = 0;
-                }
-                team.addPlayer(handle.getBukkitEntity());
-
-                handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                Util.sendTeamPacketToOnlinePlayers(team, mode);
             }
         }, 20);
 
@@ -102,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();

--- a/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/util/NMSImpl.java
+++ b/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/util/NMSImpl.java
@@ -270,7 +270,6 @@ import net.minecraft.server.v1_16_R3.PlayerChunkMap.EntityTracker;
 import net.minecraft.server.v1_16_R3.RegistryBlocks;
 import net.minecraft.server.v1_16_R3.ReportedException;
 import net.minecraft.server.v1_16_R3.ScoreboardTeam;
-import net.minecraft.server.v1_16_R3.ScoreboardTeamBase.EnumNameTagVisibility;
 import net.minecraft.server.v1_16_R3.SoundEffect;
 import net.minecraft.server.v1_16_R3.TagsFluid;
 import net.minecraft.server.v1_16_R3.Vec3D;
@@ -1237,16 +1236,7 @@ public class NMSImpl implements NMSBridge {
 
     @Override
     public void setTeamNameTagVisible(Team team, boolean visible) {
-        if (TEAM_FIELD == null) {
-            TEAM_FIELD = NMS.getGetter(team.getClass(), "team");
-        }
-        ScoreboardTeam nmsTeam;
-        try {
-            nmsTeam = (ScoreboardTeam) TEAM_FIELD.invoke(team);
-            nmsTeam.setNameTagVisibility(visible ? EnumNameTagVisibility.ALWAYS : EnumNameTagVisibility.NEVER);
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
+        team.setOption(Team.Option.NAME_TAG_VISIBILITY, visible ? Team.OptionStatus.ALWAYS : Team.OptionStatus.NEVER);
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/HumanController.java
@@ -7,9 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.NameTagVisibility;
-import org.bukkit.scoreboard.Scoreboard;
-import org.bukkit.scoreboard.Team;
 
 import com.mojang.authlib.GameProfile;
 
@@ -48,6 +45,10 @@ public class HumanController extends AbstractEntityController {
             name = teamName;
         }
 
+        if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+            Util.generateTeamFor(npc, name, teamName);
+        }
+
         final GameProfile profile = new GameProfile(uuid, name);
 
         final EntityHumanNPC handle = new EntityHumanNPC(nmsWorld.getServer().getServer(), nmsWorld, profile,
@@ -67,25 +68,6 @@ public class HumanController extends AbstractEntityController {
                 boolean removeFromPlayerList = npc.data().get("removefromplayerlist",
                         Setting.REMOVE_PLAYERS_FROM_PLAYER_LIST.asBoolean());
                 NMS.addOrRemoveFromPlayerList(getBukkitEntity(), removeFromPlayerList);
-
-                if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
-                    Scoreboard scoreboard = Util.getDummyScoreboard();
-
-                    Team team = scoreboard.getTeam(teamName);
-                    int mode = 2;
-                    if (team == null) {
-                        team = scoreboard.registerNewTeam(teamName);
-                        if (npc.requiresNameHologram()) {
-                            team.setNameTagVisibility(NameTagVisibility.NEVER);
-                        }
-                        mode = 0;
-                    }
-                    team.addPlayer(handle.getBukkitEntity());
-
-                    handle.getNPC().data().set(NPC.SCOREBOARD_FAKE_TEAM_NAME_METADATA, teamName);
-
-                    Util.sendTeamPacketToOnlinePlayers(team, mode);
-                }
             }
         }, 20);
 
@@ -103,6 +85,9 @@ public class HumanController extends AbstractEntityController {
     public void remove() {
         Player entity = getBukkitEntity();
         if (entity != null) {
+            if (Setting.USE_SCOREBOARD_TEAMS.asBoolean()) {
+                Util.removeTeamFor(NMS.getNPC(entity), entity.getName());
+            }
             NMS.removeFromWorld(entity);
             SkinnableEntity npc = entity instanceof SkinnableEntity ? (SkinnableEntity) entity : null;
             npc.getSkinTracker().onRemoveNPC();


### PR DESCRIPTION
## The Original Problem Report

This is a followup from a post by `Mystic_Mark_` on Discord, who reported that setting `NAMEPLATE_VISIBLE_METADATA` to `false` doesn't apply until a second or two after the NPC is spawned, even if the setting is applied before spawn.

This also fixes a standing issue that NPCs with names that need holograms would initially spawn with two nameplates (the internal one, and the hologram) and the internal one would only disappear after a second. With this PR, it now spawns with only the hologram name.

This also cleans up some code duplication in the NMS modules, which is nice.

-----

## Analysis

So the logic of how scoreboard packets are sent atm is:
The `add` call (mode 0 = add) is from
`HumanController#createEntity` adds a scheduled task for `20` ticks later
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/HumanController.java#L60
that runnable creates, registers, and sends the team out with default values - it will set nameplates invis if a hologram is used here, but it doesn't check other team settings like name plate visible metadata (it checking holograms at all happens from a PR i did to fix a similar issue: https://github.com/CitizensDev/Citizens2/pull/2302 )
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/HumanController.java#L87

------

The next packet theoretically happens from path:
`CitizensNPC#spawn()` -> very last call is `updateCustomName()`
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java#L328
`CitizensNPC#updateCustomName()` -> very last call is `getOrAddTrait(ScoreboardTrait.class).apply(team, nameVisibility);`
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java#L425
`ScoreboardTrait#apply(...` -> configures the team properly (and applies name plate visible metadata) and then the very last call is `Util.sendTeamPacketToOnlinePlayers(team, 2)` which sends the `update` packet (mode 2 = update)
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java#L106

However this will actually get skipped, as it happens before the the scheduler in HumanController is called

------

Then, `CitizensNPC#update` will eventually hit `Setting.PACKET_UPDATE_DELAY` at which point it calls `CitizensNPC#updateCustomName()` which then _finally_ actually applies the name visible metadata and sends it out.
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java#L377

------

## Solutions

The most basic reduced-impact would be to add nameplate-visible-metadata check at:
https://github.com/CitizensDev/Citizens2/blob/8c120aae52c8dd598bb1060f43d108a88f7c79e9/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/HumanController.java#L78
This would reduce it to a guaranteed 1 second exactly.
However, that's not really a good fix as it's still visible for that one second, and doesn't account for other scoreboard settings that might matter.

The next possible idea is to call `ScoreboardTrait#apply` inside the relevant NMS, to set it correctly. This would be messy to alter existing code to work with, but would be reduce the chance of this bug affecting any other scoreboard settings in the future.
It would, however, still have the 1 second delay.

The 1 second delay, can be fixed theoretically as simply as... not waiting 1 second. The only reason that delay is needed (as far as I'm aware) is to avoid anything exploding if the NPC spawn fails.
This would allow instant value setting, and also mean that the normal application of `ScoreboardTrait` can happen immediately within the `spawn()` call path.

The ideal execution time for the scoreboard setup would be before the NPC even spawns. This would guarantee there's no possible delay in the scoreboard application, as the client will have the correct scoreboard values at time of spawn. Therefore, this PR does exactly that.

-----

## This PR

Changes and reasoning:
- `addPlayer` was deprecated somewhere in time, and `addEntry` has been available as far back as 1.8, so there's no harm in changing that over (doing so is necessary to be able to apply the update *before* spawn). `addPlayer` is just implemented as `addEntry(player.getName())` in craftbukkit source anyway.
- I moved the scoreboard generate/delete code into the `Util` class to avoid duplication into all 8 NMS modules.
- I moved the team removal out of `EventListen` and into `destroy()` to unify the handling location, which should account for rapid spawn/despawn, failed spawns, etc.
- Changed `NMSImpl#setTeamNameTagVisible` to use the Bukkit API in all versions other than 1.8, to remove the redundant reflection and allow calling that method from `Util` rather than having a version check (this should maybe just be refactored to having `NMS` contain the Bukkit API call and only call the bridge if the version == 1.8 ... or better just drop 1.8 support so things like that can be avoided entirely)
- The team generation code now checks `NAMEPLATE_VISIBLE_METADATA` in addition to `requiresNameHologram`. The logic for how it's checked was based on `CitizensNPC#updateCustomName` and `CitizensNPC#updateCustomNameVisibility` 

I did my best to fit the formatting of Citizens code, including alphabetical method ordering and all.

The `HumanController` revision has been copied to all modules.

-----

## Testing


- This has only tested in 1.16. I don't think there's any reason it would break in prior versions other than maaaybe 1.8 just because as I must usually note - 1.8's code is significantly different in a lot of places and I'm not going to test a 7 year old minecraft version.
- Tested thoroughly messing with name settings with both normal named NPCs (like `/npc create bob`) and with very long named NPCs that had hologram names
- Everything seems to work as expected, no client errors, `/npc name` works as expected, if name is off when an NPC spawns, it is never visible for even a millisecond. Hologram name NPCs never get the weird duplicate layer.

-----

## Possible Future Change

Note that this PR only applies name tag visibility before spawn time, all other ScoreboardTrait settings are only applied immediately after spawn (same tick at least). If other settings need to be applied *before* like name-tag-visibility does, it might be worth while to transfer ScoreboardTrait's settings into somewhere that `Util` can access, and apply with within the `generateTeamFor` method.
