### PR TITLE
Fix updated versions of Netty on 1.8

### DIFF
--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/network/EmptyChannel.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/network/EmptyChannel.java
@@ -7,10 +7,31 @@ import io.netty.channel.ChannelMetadata;
 import io.netty.channel.ChannelOutboundBuffer;
 import io.netty.channel.DefaultChannelConfig;
 import io.netty.channel.EventLoop;
+import io.netty.util.Version;
 
 import java.net.SocketAddress;
 
 public class EmptyChannel extends AbstractChannel {
+
+    private static boolean updatedNetty = false;
+
+    static {
+        Version nettyVersion = Version.identify().get("netty-common");
+        if (nettyVersion != null) {
+            String[] split = nettyVersion.artifactVersion().split("\\.");
+            try {
+                int major = Integer.parseInt(split[0]);
+                int minor = Integer.parseInt(split[1]);
+                int revision = Integer.parseInt(split[2]);
+
+                if (major > 4 || minor > 1 || revision > 24) {
+                    updatedNetty = true;
+                }
+            } catch (NumberFormatException | ArrayIndexOutOfBoundsException ignored) {
+            }
+        }
+    }
+
     private final ChannelConfig config = new DefaultChannelConfig(this);
 
     public EmptyChannel(Channel parent) {
@@ -65,7 +86,7 @@ public class EmptyChannel extends AbstractChannel {
 
     @Override
     public ChannelMetadata metadata() {
-        return null;
+        return updatedNetty ? new ChannelMetadata(true) : null;
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/network/EmptyChannel.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/network/EmptyChannel.java
@@ -10,13 +10,17 @@ import io.netty.channel.EventLoop;
 import io.netty.util.Version;
 
 import java.net.SocketAddress;
+import java.util.Map;
 
 public class EmptyChannel extends AbstractChannel {
 
     private static boolean updatedNetty = false;
 
     static {
-        Version nettyVersion = Version.identify().get("netty-common");
+        Map<String, Version> versionMap = Version.identify();
+        Version nettyVersion = versionMap.get("netty-common");
+        if (nettyVersion == null) nettyVersion = versionMap.get("netty-all");
+
         if (nettyVersion != null) {
             String[] split = nettyVersion.artifactVersion().split("\\.");
             try {


### PR DESCRIPTION
Hello,
This fixes an incompatibility with 1.8 servers that have updated their version of Netty (to support Java 9-17).
Basically, it checks the Netty version and if it is newer then it will provide a fix for it.
I tested it on Spigot 1.8 (old netty), and a server with the latest Netty version, everything seems to be working fine.
Thank you