### PR TITLE
SkinTrait should only update if the Placeholder changes

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/SkinTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/SkinTrait.java
@@ -37,7 +37,7 @@ public class SkinTrait extends Trait {
         if (skinName == null)
             return;
         String filled = ChatColor.stripColor(Placeholders.replace(skinName, null, npc).toLowerCase());
-        if (!filled.equalsIgnoreCase(filledPlaceholder)) {
+        if (!filled.equalsIgnoreCase(skinName) && !filled.equalsIgnoreCase(filledPlaceholder)) {
             filledPlaceholder = filled;
             if (update) {
                 onSkinChange(true);

--- a/main/src/main/java/net/citizensnpcs/trait/SkinTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/SkinTrait.java
@@ -37,7 +37,7 @@ public class SkinTrait extends Trait {
         if (skinName == null)
             return;
         String filled = ChatColor.stripColor(Placeholders.replace(skinName, null, npc).toLowerCase());
-        if (!filled.equalsIgnoreCase(skinName)) {
+        if (!filled.equalsIgnoreCase(filledPlaceholder)) {
             filledPlaceholder = filled;
             if (update) {
                 onSkinChange(true);


### PR DESCRIPTION
This fixes an issue where re parsing a placeholder re rendered the skin, even if the skin did not actually change.