### PR TITLE
Improve Util#requiresNettyChannelMetadata - support newer netty version

### DIFF
--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -347,7 +347,7 @@ public class Util {
         try {
             Integer[] parts = Iterables.toArray(
                     Iterables.transform(Splitter.on('.').split(version.artifactVersion()), string -> {
-                        // Newer versions of netty use suffix (like .Final) that can't be parsed to String
+                        // Newer versions of netty use suffix (like .Final) that can't be parsed to Integer
                         try {
                             return Integer.parseInt(string);
                         } catch (NumberFormatException e) {

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -346,9 +346,19 @@ public class Util {
             return REQUIRES_CHANNEL_METADATA = false;
         try {
             Integer[] parts = Iterables.toArray(
-                    Iterables.transform(Splitter.on('.').split(version.artifactVersion()), s -> Integer.parseInt(s)),
+                    Iterables.transform(Splitter.on('.').split(version.artifactVersion()), string -> {
+                        // Newer versions of netty use suffix (like .Final) that can't be parsed to String
+                        try {
+                            return Integer.parseInt(string);
+                        } catch (NumberFormatException e) {
+                            return -1;
+                        }
+                    }),
                     int.class);
-            return REQUIRES_CHANNEL_METADATA = parts[0] > 4 || (parts[0] == 4 && parts[1] > 1);
+            int major = parts[0];
+            int minor = parts[1];
+            int patch = parts[2];
+            return REQUIRES_CHANNEL_METADATA = major >= 5 || major == 4 && minor > 1 || patch >= 64;
         } catch (Throwable t) {
             t.printStackTrace();
             return REQUIRES_CHANNEL_METADATA = true;


### PR DESCRIPTION
This PR fix support for newer netty versions.

1. Since Netty 4.1.64 (exactly [this commit](https://github.com/netty/netty/commit/c3416d8ad2260f3c9bc98a9061d25bba92020f93#diff-c46b1a224c36824967af904de88fa1732e0e4f57450cfb14b4ad70143ec9ea20)) ChannelMetadata is required and can't be null
2. Newer Netty version also add .Final to version so it can't be parsed properly