### PR TITLE
Make pathfinder max visited node count configurable

### DIFF
--- a/main/src/main/java/net/citizensnpcs/Settings.java
+++ b/main/src/main/java/net/citizensnpcs/Settings.java
@@ -125,6 +125,7 @@ public class Settings {
         MAX_SPEED("npc.limits.max-speed", 100),
         MAX_TEXT_RANGE("npc.chat.options.max-text-range", 500),
         MAXIMUM_ASTAR_ITERATIONS("npc.pathfinding.maximum-new-pathfinder-iterations", 10000),
+        MAXIMUM_VISITED_NODES("npc.pathfinding.maximum-visited-nodes", 768),
         MC_NAVIGATION_MAX_FALL_DISTANCE("npc.pathfinding.minecraft.max-fall-distance", 3),
         MESSAGE_COLOUR("general.color-scheme.message", "<a>"),
         NEW_PATHFINDER_CHECK_BOUNDING_BOXES("npc.pathfinding.new-finder.check-bounding-boxes", false),

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerNavigation.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/PlayerNavigation.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 
+import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.nms.v1_14_R1.entity.EntityHumanNPC;
 import net.minecraft.server.v1_14_R1.AttributeInstance;
 import net.minecraft.server.v1_14_R1.Block;
@@ -65,7 +66,7 @@ public class PlayerNavigation extends NavigationAbstract {
         this.p = entityinsentient.getAttributeInstance(GenericAttributes.FOLLOW_RANGE);
         this.o = new PlayerPathfinderNormal();
         this.o.a(true);
-        this.s = new PlayerPathfinder(this.o, 768);
+        this.s = new PlayerPathfinder(this.o, Setting.MAXIMUM_VISITED_NODES.asInt());
         this.setRange(24);
         // this.b.C().a(this);
     }

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerNavigation.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/PlayerNavigation.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 
+import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.nms.v1_15_R1.entity.EntityHumanNPC;
 import net.minecraft.server.v1_15_R1.AttributeInstance;
 import net.minecraft.server.v1_15_R1.Block;
@@ -65,7 +66,7 @@ public class PlayerNavigation extends NavigationAbstract {
         this.p = entityinsentient.getAttributeInstance(GenericAttributes.FOLLOW_RANGE);
         this.o = new PlayerPathfinderNormal();
         this.o.a(true);
-        this.t = new PlayerPathfinder(this.o, 768);
+        this.t = new PlayerPathfinder(this.o, Setting.MAXIMUM_VISITED_NODES.asInt());
         this.setRange(24);
         // this.b.C().a(this);
     }

--- a/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/util/PlayerNavigation.java
+++ b/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/util/PlayerNavigation.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 
+import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.nms.v1_16_R3.entity.EntityHumanNPC;
 import net.minecraft.server.v1_16_R3.AttributeModifiable;
 import net.minecraft.server.v1_16_R3.BaseBlockPosition;
@@ -66,7 +67,7 @@ public class PlayerNavigation extends NavigationAbstract {
         this.followRange = entityinsentient.getAttributeInstance(GenericAttributes.FOLLOW_RANGE);
         this.o = new PlayerPathfinderNormal();
         this.o.a(true);
-        this.s = new PlayerPathfinder(this.o, 768);
+        this.s = new PlayerPathfinder(this.o, Setting.MAXIMUM_VISITED_NODES.asInt());
         this.setRange(24);
         // this.b.C().a(this);
     }

--- a/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/util/PlayerNavigation.java
+++ b/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/util/PlayerNavigation.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 
+import net.citizensnpcs.Settings.Setting;
 import net.citizensnpcs.nms.v1_17_R1.entity.EntityHumanNPC;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
@@ -61,7 +62,7 @@ public class PlayerNavigation extends PathNavigation {
         this.followRange = entityinsentient.getAttribute(Attributes.FOLLOW_RANGE);
         this.nodeEvaluator = new PlayerNodeEvaluator();
         this.nodeEvaluator.setCanPassDoors(true);
-        this.pathFinder = new PlayerPathfinder(this.nodeEvaluator, 768);
+        this.pathFinder = new PlayerPathfinder(this.nodeEvaluator, Setting.MAXIMUM_VISITED_NODES.asInt());
         this.setRange(24);
     }
 

--- a/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/util/PlayerPathfinder.java
+++ b/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/util/PlayerPathfinder.java
@@ -33,10 +33,10 @@ public class PlayerPathfinder extends PathFinder {
     private final BinaryHeap openSet;
 
     public PlayerPathfinder() {
-        super(null, 768);
+        super(null, Setting.MAXIMUM_VISITED_NODES.asInt());
         this.nodeEvaluator = new PlayerNodeEvaluator();
         this.openSet = new BinaryHeap();
-        this.maxVisitedNodes = 768;
+        this.maxVisitedNodes = Setting.MAXIMUM_VISITED_NODES.asInt();
     }
 
     public PlayerPathfinder(PlayerNodeEvaluator var0, int var1) {

--- a/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/util/PlayerNavigation.java
+++ b/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/util/PlayerNavigation.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 
+import net.citizensnpcs.Settings;
 import net.citizensnpcs.nms.v1_18_R2.entity.EntityHumanNPC;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
@@ -60,7 +61,7 @@ public class PlayerNavigation extends PathNavigation {
         this.followRange = entityinsentient.getAttribute(Attributes.FOLLOW_RANGE);
         this.nodeEvaluator = new PlayerNodeEvaluator();
         this.nodeEvaluator.setCanPassDoors(true);
-        this.pathFinder = new PlayerPathfinder(this.nodeEvaluator, 768);
+        this.pathFinder = new PlayerPathfinder(this.nodeEvaluator, Settings.Setting.MAXIMUM_VISITED_NODES.asInt());
         this.setRange(24);
     }
 

--- a/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/util/PlayerPathfinder.java
+++ b/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/util/PlayerPathfinder.java
@@ -32,10 +32,10 @@ public class PlayerPathfinder extends PathFinder {
     private final BinaryHeap openSet;
 
     public PlayerPathfinder() {
-        super(null, 768);
+        super(null, Setting.MAXIMUM_VISITED_NODES.asInt());
         this.nodeEvaluator = new PlayerNodeEvaluator();
         this.openSet = new BinaryHeap();
-        this.maxVisitedNodes = 768;
+        this.maxVisitedNodes = Setting.MAXIMUM_VISITED_NODES.asInt();
     }
 
     public PlayerPathfinder(PlayerNodeEvaluator var0, int var1) {

--- a/v1_19_R1/src/main/java/net/citizensnpcs/nms/v1_19_R1/util/PlayerNavigation.java
+++ b/v1_19_R1/src/main/java/net/citizensnpcs/nms/v1_19_R1/util/PlayerNavigation.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 
+import net.citizensnpcs.Settings;
 import net.citizensnpcs.nms.v1_19_R1.entity.EntityHumanNPC;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
@@ -28,6 +29,7 @@ import net.minecraft.world.level.pathfinder.Path;
 import net.minecraft.world.level.pathfinder.PathFinder;
 import net.minecraft.world.level.pathfinder.WalkNodeEvaluator;
 import net.minecraft.world.phys.Vec3;
+import org.bukkit.Bukkit;
 
 public class PlayerNavigation extends PathNavigation {
     private boolean avoidSun;
@@ -60,7 +62,7 @@ public class PlayerNavigation extends PathNavigation {
         this.followRange = entityinsentient.getAttribute(Attributes.FOLLOW_RANGE);
         this.nodeEvaluator = new PlayerNodeEvaluator();
         this.nodeEvaluator.setCanPassDoors(true);
-        this.pathFinder = new PlayerPathfinder(this.nodeEvaluator, 768);
+        this.pathFinder = new PlayerPathfinder(this.nodeEvaluator, Settings.Setting.MAXIMUM_VISITED_NODES.asInt());
         this.setRange(24);
     }
 

--- a/v1_19_R1/src/main/java/net/citizensnpcs/nms/v1_19_R1/util/PlayerPathfinder.java
+++ b/v1_19_R1/src/main/java/net/citizensnpcs/nms/v1_19_R1/util/PlayerPathfinder.java
@@ -31,13 +31,6 @@ public class PlayerPathfinder extends PathFinder {
     private final PlayerNodeEvaluator nodeEvaluator;
     private final BinaryHeap openSet;
 
-    public PlayerPathfinder() {
-        super(null, 768);
-        this.nodeEvaluator = new PlayerNodeEvaluator();
-        this.openSet = new BinaryHeap();
-        this.maxVisitedNodes = 768;
-    }
-
     public PlayerPathfinder(PlayerNodeEvaluator var0, int var1) {
         super(var0, var1);
         this.openSet = new BinaryHeap();


### PR DESCRIPTION
I have bumped into pathfinding failures with NPCs trying to move through complex geometry using the Minecraft pathfinder. 
Eventually, I was able to narrow down the issue to the pathfinder needing to explore more nodes than the default value of 768, which seems to be hard-coded at the moment.

I propose we make this configurable, so that people have a way out of the problem I encountered.