### PR TITLE
Don't use google commons in Util#requiresNettyChannelMetadata

### DIFF
--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -347,7 +347,7 @@ public class Util {
         try {
             Integer[] parts = Iterables.toArray(
                     Iterables.transform(Splitter.on('.').split(version.artifactVersion()), string -> {
-                        // Newer versions of netty use suffix (like .Final) that can't be parsed to String
+                        // Newer versions of netty use suffix (like .Final) that can't be parsed to Integer
                         try {
                             return Integer.parseInt(string);
                         } catch (NumberFormatException e) {

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -346,9 +346,19 @@ public class Util {
             return REQUIRES_CHANNEL_METADATA = false;
         try {
             Integer[] parts = Iterables.toArray(
-                    Iterables.transform(Splitter.on('.').split(version.artifactVersion()), s -> Integer.parseInt(s)),
+                    Iterables.transform(Splitter.on('.').split(version.artifactVersion()), string -> {
+                        // Newer versions of netty use suffix (like .Final) that can't be parsed to String
+                        try {
+                            return Integer.parseInt(string);
+                        } catch (NumberFormatException e) {
+                            return -1;
+                        }
+                    }),
                     int.class);
-            return REQUIRES_CHANNEL_METADATA = parts[0] > 4 || (parts[0] == 4 && parts[1] > 1);
+            int major = parts[0];
+            int minor = parts[1];
+            int patch = parts[2];
+            return REQUIRES_CHANNEL_METADATA = major >= 5 || major == 4 && minor > 1 || patch >= 64;
         } catch (Throwable t) {
             t.printStackTrace();
             return REQUIRES_CHANNEL_METADATA = true;

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
+import java.util.stream.StreamSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -345,20 +346,18 @@ public class Util {
         if (version == null)
             return REQUIRES_CHANNEL_METADATA = false;
         try {
-            Integer[] parts = Iterables.toArray(
-                    Iterables.transform(Splitter.on('.').split(version.artifactVersion()), string -> {
-                        // Newer versions of netty use suffix (like .Final) that can't be parsed to Integer
-                        try {
-                            return Integer.parseInt(string);
-                        } catch (NumberFormatException e) {
-                            return -1;
-                        }
-                    }),
-                    int.class);
+           Integer[] parts = StreamSupport.stream(Splitter.on('.').split(version.artifactVersion()).spliterator(), false).map(string -> {
+               // Newer versions of netty use suffix (like .Final) that can't be parsed to Integer
+               try {
+                   return Integer.parseInt(string);
+               } catch (NumberFormatException e) {
+                   return -1;
+               }
+           }).toArray(Integer[]::new);
             int major = parts[0];
             int minor = parts[1];
             int patch = parts[2];
-            return REQUIRES_CHANNEL_METADATA = major >= 5 || major == 4 && minor > 1 || patch >= 64;
+            return REQUIRES_CHANNEL_METADATA = major >= 5 || major == 4 && (minor > 1 || patch >= 64);
         } catch (Throwable t) {
             t.printStackTrace();
             return REQUIRES_CHANNEL_METADATA = true;


### PR DESCRIPTION
For some reason google commons is throwing this error:
```
[22:58:29] [Server thread/WARN]: java.lang.ClassCastException: [I cannot be cast to [Ljava.lang.Object;
[22:58:29] [Server thread/WARN]: 	at com.google.common.collect.ObjectArrays.newArray(ObjectArrays.java:49)
[22:58:29] [Server thread/WARN]: 	at com.google.common.collect.Iterables.toArray(Iterables.java:280)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.util.Util.requiresNettyChannelMetadata(Util.java:360)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.network.EmptyChannel.metadata(EmptyChannel.java:69)
[22:58:29] [Server thread/WARN]: 	at io.netty.channel.DefaultChannelConfig.<init>(DefaultChannelConfig.java:79)
[22:58:29] [Server thread/WARN]: 	at io.netty.channel.DefaultChannelConfig.<init>(DefaultChannelConfig.java:75)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.network.EmptyChannel.<init>(EmptyChannel.java:15)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.util.NMSImpl.initNetworkManager(NMSImpl.java:1476)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.network.EmptyNetworkManager.<init>(EmptyNetworkManager.java:12)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.entity.EntityHumanNPC.initialise(EntityHumanNPC.java:250)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.entity.EntityHumanNPC.<init>(EntityHumanNPC.java:79)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.nms.v1_8_R3.entity.HumanController.createEntity(HumanController.java:55)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.npc.AbstractEntityController.spawn(AbstractEntityController.java:41)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.npc.CitizensNPC.spawn(CitizensNPC.java:259)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.npc.CitizensNPC.load(CitizensNPC.java:164)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.api.npc.SimpleNPCDataStore.loadInto(SimpleNPCDataStore.java:59)
[22:58:29] [Server thread/WARN]: 	at net.citizensnpcs.Citizens$CitizensLoadTask.run(Citizens.java:520)
[22:58:29] [Server thread/WARN]: 	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftTask.run(CraftTask.java:64)
[22:58:29] [Server thread/WARN]: 	at org.bukkit.craftbukkit.v1_8_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:412)
[22:58:29] [Server thread/WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:1090)
[22:58:29] [Server thread/WARN]: 	at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:414)
[22:58:29] [Server thread/WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:992)
[22:58:29] [Server thread/WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:803)
[22:58:29] [Server thread/WARN]: 	at net.minecraft.server.v1_8_R3.MinecraftServer.lambda$spin$0(MinecraftServer.java:140)
```

So I just replaced it with plain java - I tested this and on Java 8, 11, 17 everything still works

Also fixed condition and added missing brackets