### PR TITLE
Trial delaying scoreboard removal on death v2

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
@@ -92,6 +92,8 @@ public class ScoreboardTrait extends Trait {
         if (team == null || name == null || !team.hasEntry(name))
             return;
         Bukkit.getScheduler().scheduleSyncDelayedTask(CitizensAPI.getPlugin(), () -> {
+            if (npc.getEntity() instanceof LivingEntity)
+                return;
             if (team.getSize() == 1) {
                 for (Player player : Bukkit.getOnlinePlayers()) {
                     metadata.remove(player.getUniqueId(), team.getName());


### PR DESCRIPTION
NPC was spawning without any ScoreboardTrait tag if spawning twice due to skin change. This pr aborts the process if NPC is alive after cooldown.