### PR TITLE
Refactor FallingExaminer and improve pathfinding debugging

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/CitizensNavigator.java
@@ -294,6 +294,9 @@ public class CitizensNavigator implements Navigator, Runnable {
             cancelNavigation();
             return;
         }
+        if (isNavigating()) {
+            cancelNavigation(CancelReason.REPLACE);
+        }
         setTarget(params -> {
             params.straightLineTargetingDistance(100000);
             return new MCTargetStrategy(npc, target, aggressive, params);
@@ -309,6 +312,9 @@ public class CitizensNavigator implements Navigator, Runnable {
             cancelNavigation();
             return;
         }
+        if (isNavigating()) {
+            cancelNavigation(CancelReason.REPLACE);
+        }
         setTarget(params -> new StraightLineNavigationStrategy(npc, target.clone(), params));
     }
 
@@ -321,6 +327,9 @@ public class CitizensNavigator implements Navigator, Runnable {
             cancelNavigation();
             return;
         }
+        if (isNavigating()) {
+            cancelNavigation(CancelReason.REPLACE);
+        }
         setTarget(params -> new MCTargetStrategy(npc, target, aggressive, params));
     }
 
@@ -328,6 +337,9 @@ public class CitizensNavigator implements Navigator, Runnable {
     public void setTarget(Function<NavigatorParameters, PathStrategy> strategy) {
         if (!npc.isSpawned())
             throw new IllegalStateException("npc is not spawned");
+        if (isNavigating()) {
+            cancelNavigation(CancelReason.REPLACE);
+        }
         switchParams();
         switchStrategyTo(strategy.apply(localParams));
     }
@@ -339,6 +351,9 @@ public class CitizensNavigator implements Navigator, Runnable {
         if (path == null || Iterables.size(path) == 0) {
             cancelNavigation();
             return;
+        }
+        if (isNavigating()) {
+            cancelNavigation(CancelReason.REPLACE);
         }
         setTarget(params -> {
             if (npc.isFlyable()) {
@@ -358,6 +373,9 @@ public class CitizensNavigator implements Navigator, Runnable {
         if (targetIn == null) {
             cancelNavigation();
             return;
+        }
+        if (isNavigating()) {
+            cancelNavigation(CancelReason.REPLACE);
         }
         Location target = targetIn.clone();
         setTarget(params -> {

--- a/main/src/main/java/net/citizensnpcs/npc/ai/FallingExaminer.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/FallingExaminer.java
@@ -33,8 +33,11 @@ public class FallingExaminer implements BlockExaminer {
         PathPoint parentPoint = point.getParentPoint();
         Vector parentPos = parentPoint != null ? parentPoint.getVector() : null;
 
-        // Ignore points above the previous point to fix "falling up"
         if (parentPos != null && pos.getBlockY() > parentPos.getBlockY()) {
+            return PassableState.IGNORE;
+        }
+
+        if (!MinecraftBlockExaminer.canStandIn(source.getBlockAt(pos.getBlockX(), pos.getBlockY(), pos.getBlockZ()))) {
             return PassableState.IGNORE;
         }
 

--- a/main/src/main/java/net/citizensnpcs/npc/ai/MCTargetStrategy.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/MCTargetStrategy.java
@@ -158,6 +158,9 @@ public class MCTargetStrategy implements PathStrategy, EntityTarget {
         @Override
         public void setPath() {
             // TODO: should use fallback-style pathfinding
+            if (strategy != null) {
+                strategy.stop();
+            }
             setStrategy();
             strategy.update();
             CancelReason subReason = strategy.getCancelReason();


### PR DESCRIPTION
This pull request includes small changes to CitizensNavigator to properly stop/cancel old strategy instances before constructing the new ones, allowing for the clearing of old debug paths. The FallingExaminer has also been updated to avoid passing points inside solid blocks.