### PR TITLE
Added Auto Completion for Cat Types

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/versioned/CatTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/versioned/CatTrait.java
@@ -105,7 +105,15 @@ public class CatTrait extends Trait {
             permission = "citizens.npc.cat")
     @Requirements(selected = true, ownership = true, types = EntityType.CAT)
     public static void cat(CommandContext args, CommandSender sender, NPC npc, @Flag("ccolor") DyeColor ccolor,
-            @Flag("type") Cat.Type type) throws CommandException {
+                           @Flag(
+                                   value = "type",
+                                   completions = {
+                                           "TABBY", "BLACK", "RED",
+                                           "SIAMESE", "BRITISH_SHORTHAIR", "CALICO",
+                                           "PERSIAN", "RAGDOLL", "WHITE",
+                                           "JELLIE", "ALL_BLACK"
+                                   }
+                           ) Cat.Type type) throws CommandException {
         CatTrait trait = npc.getOrAddTrait(CatTrait.class);
         String output = "";
         if (args.hasValueFlag("type")) {


### PR DESCRIPTION
In the new versions, there was no auto-complete for the cat types. The command still worked, there were just no suggestions popping up when editing the cat.

`/npc cat --type (TYPE)` now correctly displays the auto-complete types.