### PR TITLE
fix: remove duplicate entity controller definition for POTION in 1.21

### DIFF
--- a/v1_21_R1/src/main/java/net/citizensnpcs/nms/v1_21_R1/util/NMSImpl.java
+++ b/v1_21_R1/src/main/java/net/citizensnpcs/nms/v1_21_R1/util/NMSImpl.java
@@ -1047,7 +1047,6 @@ public class NMSImpl implements NMSBridge {
         EntityControllers.setEntityControllerForType(EntityType.PLAYER, HumanController.class);
         EntityControllers.setEntityControllerForType(EntityType.POLAR_BEAR, PolarBearController.class);
         EntityControllers.setEntityControllerForType(EntityType.POTION, ThrownPotionController.class);
-        EntityControllers.setEntityControllerForType(EntityType.POTION, ThrownPotionController.class);
         EntityControllers.setEntityControllerForType(EntityType.PUFFERFISH, PufferFishController.class);
         EntityControllers.setEntityControllerForType(EntityType.RABBIT, RabbitController.class);
         EntityControllers.setEntityControllerForType(EntityType.RAVAGER, RavagerController.class);


### PR DESCRIPTION
I don't understand why the NMS implementation for 1.21 sets the potion entity controller twice. It seems that no other potion variants exist in Bukkit 1.21

Looking forward to reviews.