### PR TITLE
fix: EventListen changes

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -401,7 +401,7 @@ public class EventListen implements Listener {
         event.setCancelled(true);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.LOWEST) // cancel this earlier than other plugins if needed
     public void onEntityTarget(EntityTargetEvent event) {
         NPC npc = CitizensAPI.getNPCRegistry().getNPC(event.getTarget());
         if (npc == null)
@@ -409,14 +409,14 @@ public class EventListen implements Listener {
 
         final EntityTargetNPCEvent targetNPCEvent = new EntityTargetNPCEvent(event, npc);
         Bukkit.getPluginManager().callEvent(targetNPCEvent);
-        boolean originalEventCancelled;
         if (targetNPCEvent.isCancelled()) {
-            originalEventCancelled = true;
+            event.setCancelled(true);
         } else {
             // nobody cares this event so let it follow the default behaviour
-            originalEventCancelled = !npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected());
+            if (!npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected())) {
+                event.setCancelled(true);
+            }
         }
-        event.setCancelled(originalEventCancelled);
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -401,21 +401,17 @@ public class EventListen implements Listener {
         event.setCancelled(true);
     }
 
-    @EventHandler(priority = EventPriority.LOWEST) // cancel this earlier than other plugins if needed
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onEntityTarget(EntityTargetEvent event) {
         NPC npc = CitizensAPI.getNPCRegistry().getNPC(event.getTarget());
         if (npc == null)
             return;
 
         final EntityTargetNPCEvent targetNPCEvent = new EntityTargetNPCEvent(event, npc);
+        targetNPCEvent.setCancelled(!npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected()));
         Bukkit.getPluginManager().callEvent(targetNPCEvent);
         if (targetNPCEvent.isCancelled()) {
-            event.setCancelled(true);
-        } else {
-            // nobody cares this event so let it follow the default behaviour
-            if (!npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected())) {
-                event.setCancelled(true);
-            }
+            targetNPCEvent.setCancelled(true);
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -297,14 +297,17 @@ public class EventListen implements Listener {
         if (npc == null)
             return;
 
-        event.setCancelled(npc.isProtected());
-
+        final NPCCombustEvent npcCombustEvent;
         if (event instanceof EntityCombustByEntityEvent) {
-            Bukkit.getPluginManager().callEvent(new NPCCombustByEntityEvent((EntityCombustByEntityEvent) event, npc));
+            npcCombustEvent = new NPCCombustByEntityEvent((EntityCombustByEntityEvent) event, npc);
         } else if (event instanceof EntityCombustByBlockEvent) {
-            Bukkit.getPluginManager().callEvent(new NPCCombustByBlockEvent((EntityCombustByBlockEvent) event, npc));
+            npcCombustEvent = new NPCCombustByBlockEvent((EntityCombustByBlockEvent) event, npc);
         } else {
-            Bukkit.getPluginManager().callEvent(new NPCCombustEvent(event, npc));
+            npcCombustEvent = new NPCCombustEvent(event, npc);
+        }
+        Bukkit.getPluginManager().callEvent(npcCombustEvent);
+        if (npcCombustEvent.isCancelled() || npc.isProtected()) {
+            event.setCancelled(true);
         }
     }
 
@@ -319,10 +322,15 @@ public class EventListen implements Listener {
                 event.setCancelled(!npc.data().get(NPC.Metadata.DAMAGE_OTHERS, true));
                 NPCDamageEntityEvent damageEvent = new NPCDamageEntityEvent(npc, (EntityDamageByEntityEvent) event);
                 Bukkit.getPluginManager().callEvent(damageEvent);
+                if (damageEvent.isCancelled()) {
+                    event.setCancelled(true);
+                }
             }
             return;
         }
-        event.setCancelled(npc.isProtected());
+        if (npc.isProtected()) {
+            event.setCancelled(true);
+        }
 
         if (event instanceof EntityDamageByEntityEvent) {
             NPCDamageByEntityEvent damageEvent = new NPCDamageByEntityEvent(npc, (EntityDamageByEntityEvent) event);
@@ -339,13 +347,23 @@ public class EventListen implements Listener {
             }
             NPCLeftClickEvent leftClickEvent = new NPCLeftClickEvent(npc, damager);
             Bukkit.getPluginManager().callEvent(leftClickEvent);
+            if (leftClickEvent.isCancelled()) {
+                return;
+            }
             if (npc.hasTrait(CommandTrait.class)) {
                 npc.getTraitNullable(CommandTrait.class).dispatch(damager, CommandTrait.Hand.LEFT);
             }
-        } else if (event instanceof EntityDamageByBlockEvent) {
-            Bukkit.getPluginManager().callEvent(new NPCDamageByBlockEvent(npc, (EntityDamageByBlockEvent) event));
         } else {
-            Bukkit.getPluginManager().callEvent(new NPCDamageEvent(npc, event));
+            final NPCDamageEvent npcDamageEvent;
+            if (event instanceof EntityDamageByBlockEvent) {
+                npcDamageEvent = new NPCDamageByBlockEvent(npc, (EntityDamageByBlockEvent) event);
+            } else {
+                npcDamageEvent = new NPCDamageEvent(npc, event);
+            }
+            Bukkit.getPluginManager().callEvent(npcDamageEvent);
+            if (npcDamageEvent.isCancelled()) {
+                event.setCancelled(true);
+            }
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -407,8 +407,16 @@ public class EventListen implements Listener {
         if (npc == null)
             return;
 
-        event.setCancelled(!npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected()));
-        Bukkit.getPluginManager().callEvent(new EntityTargetNPCEvent(event, npc));
+        final EntityTargetNPCEvent targetNPCEvent = new EntityTargetNPCEvent(event, npc);
+        Bukkit.getPluginManager().callEvent(targetNPCEvent);
+        boolean originalEventCancelled;
+        if (targetNPCEvent.isCancelled()) {
+            originalEventCancelled = true;
+        } else {
+            // nobody cares this event so let it follow the default behaviour
+            originalEventCancelled = !npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected());
+        }
+        event.setCancelled(originalEventCancelled);
     }
 
     @EventHandler(ignoreCancelled = true)


### PR DESCRIPTION
Original issue:
As the Citizens API said the EntityTargetNPCEvent should be cancellable (it implemented Cancellable) but the plugin did not care about the fired event.
So this PR make the "setCancelled" method really work for that.
Actually I'm not sure about what to do if nobody cares the event. Is "isCancelled" returns false = the target event should not be cancelled?
Further review and discussion is needed.

Update:
I've found that some other events are cancellable, but their isCancelled properties are also got ignored. Fixing them in this PR as well. New updates are ready to be reviewed but the PR should be finally checked when I finished all changes.
And there is also some informal designs in EventListen code