### PR TITLE
fix: NPC.isProtected() should be passed to the combust event

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -327,8 +327,11 @@ public class EventListen implements Listener {
         } else {
             npcCombustEvent = new NPCCombustEvent(event, npc);
         }
+        if (npc.isProtected()) {
+            npcCombustEvent.setCancelled(true);
+        }
         Bukkit.getPluginManager().callEvent(npcCombustEvent);
-        if (npcCombustEvent.isCancelled() || npc.isProtected()) {
+        if (npcCombustEvent.isCancelled()) {
             event.setCancelled(true);
         }
     }


### PR DESCRIPTION
Appends to #3156.
I think we should give devs a chance to decide if the event should really happen.

Closing this PR is ok if we shouldn't to do so.