### PR TITLE
fix(security): prevent temporary OP from being saved

### DIFF
--- a/main/src/main/java/net/citizensnpcs/util/NMS.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMS.java
@@ -972,6 +972,10 @@ public class NMS {
         BRIDGE.setWitherInvulnerableTicks(wither, ticks);
     }
 
+    public static void setOpWithoutSaving(Player player, boolean op) {
+        BRIDGE.setOpWithoutSaving(player, op);
+    }
+
     public static boolean shouldBroadcastToPlayer(NPC npc, Supplier<Boolean> defaultResponse) {
         return npc != null && npc.data().has(NPC.Metadata.NPC_SPAWNING_IN_PROGRESS) ? false : defaultResponse.get();
     }

--- a/main/src/main/java/net/citizensnpcs/util/NMSBridge.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMSBridge.java
@@ -298,6 +298,8 @@ public interface NMSBridge {
         wither.setInvulnerabilityTicks(ticks);
     }
 
+    public void setOpWithoutSaving(Player player, boolean op);
+
     public boolean shouldJump(Entity entity);
 
     public void shutdown();

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -479,7 +479,12 @@ public class Util {
             t.printStackTrace();
         } finally {
             if (op) {
-                clicker.setOp(wasOp);
+                if (!wasOp) {
+                    // Disk I/O operation caused by Player#setOp(boolean)
+                    // is not necessary here because changes on permission
+                    // are not actually saved
+                    NMS.setOpWithoutSaving(clicker, false);
+                }
             }
         }
     }

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -463,7 +463,7 @@ public class Util {
         }
         boolean wasOp = clicker.isOp();
         if (op) {
-            clicker.setOp(true);
+            NMS.setOpWithoutSaving(clicker, true);
         }
         try {
             if (bungeeServer != null) {

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -18,6 +18,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_10_R1.DedicatedPlayerList;
+import net.minecraft.server.v1_10_R1.DedicatedServer;
+import net.minecraft.server.v1_10_R1.OpList;
+import net.minecraft.server.v1_10_R1.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1314,6 +1318,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.g(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getPropertyManager().getInt("op-permission-level", 4), opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.f(playerHandle);
     }
 
     @Override

--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/util/NMSImpl.java
@@ -1323,7 +1323,6 @@ public class NMSImpl implements NMSBridge {
     @Override
     public void setOpWithoutSaving(Player player, boolean op) {
         if (player.isOp() == op) return;
-        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
         final GameProfile profile = ((CraftPlayer) player).getProfile();
         final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
         final DedicatedServer server = playerList.getServer();
@@ -1333,7 +1332,7 @@ public class NMSImpl implements NMSBridge {
         } else {
             opList.remove(profile);
         }
-        playerList.f(playerHandle);
+        player.recalculatePermissions();
     }
 
     @Override

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -1376,7 +1376,6 @@ public class NMSImpl implements NMSBridge {
     @Override
     public void setOpWithoutSaving(Player player, boolean op) {
         if (player.isOp() == op) return;
-        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
         final GameProfile profile = ((CraftPlayer) player).getProfile();
         final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
         final DedicatedServer server = playerList.getServer();
@@ -1386,7 +1385,7 @@ public class NMSImpl implements NMSBridge {
         } else {
             opList.remove(profile);
         }
-        playerList.f(playerHandle);
+        player.recalculatePermissions();
     }
 
     @Override

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/util/NMSImpl.java
@@ -18,6 +18,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_11_R1.DedicatedPlayerList;
+import net.minecraft.server.v1_11_R1.DedicatedServer;
+import net.minecraft.server.v1_11_R1.OpList;
+import net.minecraft.server.v1_11_R1.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1367,6 +1371,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.g(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getPropertyManager().getInt("op-permission-level", 4), opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.f(playerHandle);
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -1384,7 +1384,6 @@ public class NMSImpl implements NMSBridge {
     @Override
     public void setOpWithoutSaving(Player player, boolean op) {
         if (player.isOp() == op) return;
-        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
         final GameProfile profile = ((CraftPlayer) player).getProfile();
         final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
         final DedicatedServer server = playerList.getServer();
@@ -1394,7 +1393,7 @@ public class NMSImpl implements NMSBridge {
         } else {
             opList.remove(profile);
         }
-        playerList.f(playerHandle);
+        player.recalculatePermissions();
     }
 
     @Override

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/util/NMSImpl.java
@@ -19,6 +19,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_12_R1.DedicatedPlayerList;
+import net.minecraft.server.v1_12_R1.DedicatedServer;
+import net.minecraft.server.v1_12_R1.OpList;
+import net.minecraft.server.v1_12_R1.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1375,6 +1379,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.g(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getPropertyManager().getInt("op-permission-level", 4), opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.f(playerHandle);
     }
 
     @Override

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/util/NMSImpl.java
@@ -18,6 +18,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_13_R2.DedicatedPlayerList;
+import net.minecraft.server.v1_13_R2.DedicatedServer;
+import net.minecraft.server.v1_13_R2.OpList;
+import net.minecraft.server.v1_13_R2.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1411,6 +1415,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.d(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getPropertyManager().getInt("op-permission-level", 4), opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.f(playerHandle);
     }
 
     @Override

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/util/NMSImpl.java
@@ -17,6 +17,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_14_R1.DedicatedPlayerList;
+import net.minecraft.server.v1_14_R1.DedicatedServer;
+import net.minecraft.server.v1_14_R1.OpList;
+import net.minecraft.server.v1_14_R1.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1481,6 +1485,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.r(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getDedicatedServerProperties().opPermissionLevel, opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.d(playerHandle);
     }
 
     @Override

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/util/NMSImpl.java
@@ -17,6 +17,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_15_R1.DedicatedPlayerList;
+import net.minecraft.server.v1_15_R1.DedicatedServer;
+import net.minecraft.server.v1_15_R1.OpList;
+import net.minecraft.server.v1_15_R1.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1530,6 +1534,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.s(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getDedicatedServerProperties().opPermissionLevel, opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.d(playerHandle);
     }
 
     @Override

--- a/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/util/NMSImpl.java
+++ b/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/util/NMSImpl.java
@@ -17,6 +17,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_16_R3.DedicatedPlayerList;
+import net.minecraft.server.v1_16_R3.DedicatedServer;
+import net.minecraft.server.v1_16_R3.OpList;
+import net.minecraft.server.v1_16_R3.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1550,6 +1554,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.setInvul(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final EntityPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getDedicatedServerProperties().opPermissionLevel, opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.d(playerHandle);
     }
 
     @Override

--- a/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/util/NMSImpl.java
+++ b/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/util/NMSImpl.java
@@ -16,6 +16,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.dedicated.DedicatedPlayerList;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1547,6 +1551,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         WitherBoss handle = ((CraftWither) wither).getHandle();
         handle.setInvulnerableTicks(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final ServerPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final ServerOpList opList = playerList.getOps();
+        if (op) {
+            opList.add(new ServerOpListEntry(profile, server.getOperatorUserPermissionLevel(), opList.canBypassPlayerLimit(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.sendPlayerPermissionLevel(playerHandle);
     }
 
     @Override

--- a/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/util/NMSImpl.java
+++ b/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/util/NMSImpl.java
@@ -15,6 +15,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.dedicated.DedicatedPlayerList;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1557,6 +1561,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         WitherBoss handle = ((CraftWither) wither).getHandle();
         handle.setInvulnerableTicks(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final ServerPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final ServerOpList opList = playerList.getOps();
+        if (op) {
+            opList.add(new ServerOpListEntry(profile, server.getOperatorUserPermissionLevel(), opList.canBypassPlayerLimit(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.sendPlayerPermissionLevel(playerHandle);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/util/NMSImpl.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/util/NMSImpl.java
@@ -20,6 +20,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import net.minecraft.server.dedicated.DedicatedPlayerList;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1761,6 +1765,22 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         WitherBoss handle = ((CraftWither) wither).getHandle();
         handle.setInvulnerableTicks(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final ServerPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final ServerOpList opList = playerList.getOps();
+        if (op) {
+            opList.add(new ServerOpListEntry(profile, server.getOperatorUserPermissionLevel(), opList.canBypassPlayerLimit(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.sendPlayerPermissionLevel(playerHandle);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/util/NMSImpl.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/util/NMSImpl.java
@@ -18,6 +18,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import net.minecraft.server.dedicated.DedicatedPlayerList;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1802,6 +1806,22 @@ public class NMSImpl implements NMSBridge {
         } else {
             warden.setPose(Pose.STANDING);
         }
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final ServerPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final ServerOpList opList = playerList.getOps();
+        if (op) {
+            opList.add(new ServerOpListEntry(profile, server.getOperatorUserPermissionLevel(), opList.canBypassPlayerLimit(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.sendPlayerPermissionLevel(playerHandle);
     }
 
     @Override

--- a/v1_21_R1/src/main/java/net/citizensnpcs/nms/v1_21_R1/util/NMSImpl.java
+++ b/v1_21_R1/src/main/java/net/citizensnpcs/nms/v1_21_R1/util/NMSImpl.java
@@ -18,6 +18,10 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import net.minecraft.server.dedicated.DedicatedPlayerList;
+import net.minecraft.server.dedicated.DedicatedServer;
+import net.minecraft.server.players.ServerOpList;
+import net.minecraft.server.players.ServerOpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1766,6 +1770,22 @@ public class NMSImpl implements NMSBridge {
         } else {
             warden.setPose(Pose.STANDING);
         }
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final ServerPlayer playerHandle = ((CraftPlayer) player).getHandle();
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final ServerOpList opList = playerList.getOps();
+        if (op) {
+            opList.add(new ServerOpListEntry(profile, server.getOperatorUserPermissionLevel(), opList.canBypassPlayerLimit(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        playerList.sendPlayerPermissionLevel(playerHandle);
     }
 
     @Override

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/util/NMSImpl.java
@@ -19,6 +19,10 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import net.minecraft.server.v1_8_R3.DedicatedPlayerList;
+import net.minecraft.server.v1_8_R3.DedicatedServer;
+import net.minecraft.server.v1_8_R3.OpList;
+import net.minecraft.server.v1_8_R3.OpListEntry;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -1240,6 +1244,21 @@ public class NMSImpl implements NMSBridge {
     public void setWitherInvulnerableTicks(Wither wither, int ticks) {
         EntityWither handle = ((CraftWither) wither).getHandle();
         handle.r(ticks);
+    }
+
+    @Override
+    public void setOpWithoutSaving(Player player, boolean op) {
+        if (player.isOp() == op) return;
+        final GameProfile profile = ((CraftPlayer) player).getProfile();
+        final DedicatedPlayerList playerList = ((CraftServer) player.getServer()).getHandle();
+        final DedicatedServer server = playerList.getServer();
+        final OpList opList = playerList.getOPs();
+        if (op) {
+            opList.add(new OpListEntry(profile, server.getPropertyManager().getInt("op-permission-level", 4), opList.b(profile)));
+        } else {
+            opList.remove(profile);
+        }
+        player.recalculatePermissions();
     }
 
     @Override


### PR DESCRIPTION
As far as I know, the Player#setOp(boolean) method will update the player's OP status but also **save it to disk**.

For example, a player clicked the NPC with a command being executed using OP permission. The player's OP status got updated and the status temporary saved to the disk. It is expected that player's OP will got removed after the command execution
It seems to be work fine.
But let's consider some extreme situations. It is possible that the OP status will be saved forever if server (unpredictably) crashed at the time before the command execution but after setOp was done. So the player will got OP and will not be removed unless the server operator removes them manually. It is vulnerable for the server.

This PR seems to be created with a lot of changes on NMS code, but I think it is valuable to do so.

Looking forward to reviews to current code.

~Checks on usages of obfuscated NMS methods are needed as I'm not fully checked them yet.~ Done.