### PR TITLE
fix: release interaction NPC handle when owner NPC despawn

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/BoundingBoxTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/BoundingBoxTrait.java
@@ -61,6 +61,7 @@ public class BoundingBoxTrait extends Trait implements Supplier<BoundingBox> {
         npc.data().remove(NPC.Metadata.BOUNDING_BOX_FUNCTION);
         if (interaction != null) {
             interaction.destroy();
+            interaction = null;
         }
     }
 


### PR DESCRIPTION
Remove the NPC handle object from the trait object to avoid memory leak.