### PR TITLE
fix: we should cancel the original target event instead of our own version

### DIFF
--- a/main/src/main/java/net/citizensnpcs/EventListen.java
+++ b/main/src/main/java/net/citizensnpcs/EventListen.java
@@ -453,7 +453,7 @@ public class EventListen implements Listener {
         targetNPCEvent.setCancelled(!npc.data().get(NPC.Metadata.TARGETABLE, !npc.isProtected()));
         Bukkit.getPluginManager().callEvent(targetNPCEvent);
         if (targetNPCEvent.isCancelled()) {
-            targetNPCEvent.setCancelled(true);
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
Appends to #3156 .
Sorry for my mischeck on that. We should cancel the Bukkit target event instead.