### PR TITLE
fix: can't create mob NPCs

### DIFF
--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/AllayController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/AllayController.java
@@ -45,7 +45,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class AllayController extends MobEntityController {
     public AllayController() {
-        super(EntityAllayNPC.class);
+        super(EntityAllayNPC.class, EntityType.ALLAY);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ArmorStandController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ArmorStandController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ArmorStandController extends MobEntityController {
     public ArmorStandController() {
-        super(EntityArmorStandNPC.class);
+        super(EntityArmorStandNPC.class, EntityType.ARMOR_STAND);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/AxolotlController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/AxolotlController.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class AxolotlController extends MobEntityController {
     public AxolotlController() {
-        super(EntityAxolotlNPC.class);
+        super(EntityAxolotlNPC.class, EntityType.AXOLOTL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/BatController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/BatController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BatController extends MobEntityController {
     public BatController() {
-        super(EntityBatNPC.class);
+        super(EntityBatNPC.class, EntityType.BAT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/BeeController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/BeeController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BeeController extends MobEntityController {
     public BeeController() {
-        super(EntityBeeNPC.class);
+        super(EntityBeeNPC.class, EntityType.BEE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/BlazeController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/BlazeController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BlazeController extends MobEntityController {
     public BlazeController() {
-        super(EntityBlazeNPC.class);
+        super(EntityBlazeNPC.class, EntityType.BLAZE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CamelController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CamelController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CamelController extends MobEntityController {
     public CamelController() {
-        super(EntityCamelNPC.class);
+        super(EntityCamelNPC.class, EntityType.CAMEL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CatController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CatController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CatController extends MobEntityController {
     public CatController() {
-        super(EntityCatNPC.class);
+        super(EntityCatNPC.class, EntityType.CAT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CaveSpiderController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CaveSpiderController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CaveSpiderController extends MobEntityController {
     public CaveSpiderController() {
-        super(EntityCaveSpiderNPC.class);
+        super(EntityCaveSpiderNPC.class, EntityType.CAVE_SPIDER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ChickenController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ChickenController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ChickenController extends MobEntityController {
     public ChickenController() {
-        super(EntityChickenNPC.class);
+        super(EntityChickenNPC.class, EntityType.CHICKEN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CodController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CodController.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CodController extends MobEntityController {
     public CodController() {
-        super(EntityCodNPC.class);
+        super(EntityCodNPC.class, EntityType.COD);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CowController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CowController.java
@@ -42,7 +42,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CowController extends MobEntityController {
     public CowController() {
-        super(EntityCowNPC.class);
+        super(EntityCowNPC.class, EntityType.COW);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CreeperController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/CreeperController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CreeperController extends MobEntityController {
     public CreeperController() {
-        super(EntityCreeperNPC.class);
+        super(EntityCreeperNPC.class, EntityType.CREEPER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/DolphinController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/DolphinController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class DolphinController extends MobEntityController {
     public DolphinController() {
-        super(EntityDolphinNPC.class);
+        super(EntityDolphinNPC.class, EntityType.DOLPHIN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/DrownedController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/DrownedController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class DrownedController extends MobEntityController {
     public DrownedController() {
-        super(EntityDrownedNPC.class);
+        super(EntityDrownedNPC.class, EntityType.DROWNED);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EnderDragonController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EnderDragonController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderDragonController extends MobEntityController {
     public EnderDragonController() {
-        super(EntityEnderDragonNPC.class);
+        super(EntityEnderDragonNPC.class, EntityType.ENDER_DRAGON);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EndermanController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EndermanController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EndermanController extends MobEntityController {
     public EndermanController() {
-        super(EntityEndermanNPC.class);
+        super(EntityEndermanNPC.class, EntityType.ENDERMAN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EndermiteController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EndermiteController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EndermiteController extends MobEntityController {
     public EndermiteController() {
-        super(EntityEndermiteNPC.class);
+        super(EntityEndermiteNPC.class, EntityType.ENDERMITE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EvokerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EvokerController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EvokerController extends MobEntityController {
     public EvokerController() {
-        super(EntityEvokerNPC.class);
+        super(EntityEvokerNPC.class, EntityType.EVOKER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/FoxController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/FoxController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FoxController extends MobEntityController {
     public FoxController() {
-        super(EntityFoxNPC.class);
+        super(EntityFoxNPC.class, EntityType.FOX);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/FrogController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/FrogController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FrogController extends MobEntityController {
     public FrogController() {
-        super(EntityFrogNPC.class);
+        super(EntityFrogNPC.class, EntityType.FROG);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GhastController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GhastController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GhastController extends MobEntityController {
     public GhastController() {
-        super(EntityGhastNPC.class);
+        super(EntityGhastNPC.class, EntityType.GHAST);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GiantController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GiantController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GiantController extends MobEntityController {
     public GiantController() {
-        super(EntityGiantNPC.class);
+        super(EntityGiantNPC.class, EntityType.GIANT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GlowSquidController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GlowSquidController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GlowSquidController extends MobEntityController {
     public GlowSquidController() {
-        super(EntityGlowSquidNPC.class);
+        super(EntityGlowSquidNPC.class, EntityType.GLOW_SQUID);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GoatController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GoatController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GoatController extends MobEntityController {
     public GoatController() {
-        super(EntityGoatNPC.class);
+        super(EntityGoatNPC.class, EntityType.GOAT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GuardianController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GuardianController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GuardianController extends MobEntityController {
     public GuardianController() {
-        super(EntityGuardianNPC.class);
+        super(EntityGuardianNPC.class, EntityType.GUARDIAN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GuardianElderController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/GuardianElderController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GuardianElderController extends MobEntityController {
     public GuardianElderController() {
-        super(EntityGuardianElderNPC.class);
+        super(EntityGuardianElderNPC.class, EntityType.ELDER_GUARDIAN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HoglinController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HoglinController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HoglinController extends MobEntityController {
     public HoglinController() {
-        super(EntityHoglinNPC.class);
+        super(EntityHoglinNPC.class, EntityType.HOGLIN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseController extends MobEntityController {
     public HorseController() {
-        super(EntityHorseNPC.class);
+        super(EntityHorseNPC.class, EntityType.HORSE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseDonkeyController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseDonkeyController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseDonkeyController extends MobEntityController {
     public HorseDonkeyController() {
-        super(EntityHorseDonkeyNPC.class);
+        super(EntityHorseDonkeyNPC.class, EntityType.DONKEY);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseMuleController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseMuleController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseMuleController extends MobEntityController {
     public HorseMuleController() {
-        super(EntityHorseMuleNPC.class);
+        super(EntityHorseMuleNPC.class, EntityType.MULE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseSkeletonController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseSkeletonController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseSkeletonController extends MobEntityController {
     public HorseSkeletonController() {
-        super(EntityHorseSkeletonNPC.class);
+        super(EntityHorseSkeletonNPC.class, EntityType.SKELETON);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseZombieController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/HorseZombieController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseZombieController extends MobEntityController {
     public HorseZombieController() {
-        super(EntityHorseZombieNPC.class);
+        super(EntityHorseZombieNPC.class, EntityType.ZOMBIE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/IllusionerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/IllusionerController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class IllusionerController extends MobEntityController {
     public IllusionerController() {
-        super(EntityIllusionerNPC.class);
+        super(EntityIllusionerNPC.class, EntityType.ILLUSIONER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/IronGolemController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/IronGolemController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class IronGolemController extends MobEntityController {
     public IronGolemController() {
-        super(EntityIronGolemNPC.class);
+        super(EntityIronGolemNPC.class, EntityType.IRON_GOLEM);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/LlamaController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/LlamaController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class LlamaController extends MobEntityController {
     public LlamaController() {
-        super(EntityLlamaNPC.class);
+        super(EntityLlamaNPC.class, EntityType.LLAMA);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/MagmaCubeController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/MagmaCubeController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MagmaCubeController extends MobEntityController {
     public MagmaCubeController() {
-        super(EntityMagmaCubeNPC.class);
+        super(EntityMagmaCubeNPC.class, EntityType.MAGMA_CUBE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/MobEntityController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/MobEntityController.java
@@ -24,8 +24,8 @@ import net.minecraft.world.level.Level;
 public abstract class MobEntityController extends AbstractEntityController {
     private final Class<?> clazz;
 
-    protected MobEntityController(Class<?> clazz) {
-        NMS.registerEntityClass(clazz, NMSImpl.getEntityType(clazz));
+    protected MobEntityController(Class<?> clazz, EntityType<?> type) {
+        NMS.registerEntityClass(clazz, type);
         this.clazz = clazz;
     }
 

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/MushroomCowController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/MushroomCowController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MushroomCowController extends MobEntityController {
     public MushroomCowController() {
-        super(EntityMushroomCowNPC.class);
+        super(EntityMushroomCowNPC.class, EntityType.MOOSHROOM);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/OcelotController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/OcelotController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class OcelotController extends MobEntityController {
     public OcelotController() {
-        super(EntityOcelotNPC.class);
+        super(EntityOcelotNPC.class, EntityType.OCELOT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PandaController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PandaController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PandaController extends MobEntityController {
     public PandaController() {
-        super(EntityPandaNPC.class);
+        super(EntityPandaNPC.class, EntityType.PANDA);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ParrotController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ParrotController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ParrotController extends MobEntityController {
     public ParrotController() {
-        super(EntityParrotNPC.class);
+        super(EntityParrotNPC.class, EntityType.PARROT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PhantomController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PhantomController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PhantomController extends MobEntityController {
     public PhantomController() {
-        super(EntityPhantomNPC.class);
+        super(EntityPhantomNPC.class, EntityType.PHANTOM);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PigController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PigController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PigController extends MobEntityController {
     public PigController() {
-        super(EntityPigNPC.class);
+        super(EntityPigNPC.class, EntityType.PIG);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PigZombieController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PigZombieController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PigZombieController extends MobEntityController {
     public PigZombieController() {
-        super(EntityPigZombieNPC.class);
+        super(EntityPigZombieNPC.class, EntityType.ZOMBIFIED_PIGLIN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PiglinBruteController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PiglinBruteController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PiglinBruteController extends MobEntityController {
     public PiglinBruteController() {
-        super(EntityPiglinBruteNPC.class);
+        super(EntityPiglinBruteNPC.class, EntityType.PIGLIN_BRUTE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PiglinController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PiglinController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PiglinController extends MobEntityController {
     public PiglinController() {
-        super(EntityPiglinNPC.class);
+        super(EntityPiglinNPC.class, EntityType.PIGLIN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PillagerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PillagerController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PillagerController extends MobEntityController {
     public PillagerController() {
-        super(EntityPillagerNPC.class);
+        super(EntityPillagerNPC.class, EntityType.PILLAGER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PolarBearController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PolarBearController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PolarBearController extends MobEntityController {
     public PolarBearController() {
-        super(EntityPolarBearNPC.class);
+        super(EntityPolarBearNPC.class, EntityType.POLAR_BEAR);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PufferFishController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/PufferFishController.java
@@ -46,7 +46,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PufferFishController extends MobEntityController {
     public PufferFishController() {
-        super(EntityPufferFishNPC.class);
+        super(EntityPufferFishNPC.class, EntityType.PUFFERFISH);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/RabbitController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/RabbitController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class RabbitController extends MobEntityController {
     public RabbitController() {
-        super(EntityRabbitNPC.class);
+        super(EntityRabbitNPC.class, EntityType.RABBIT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/RavagerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/RavagerController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class RavagerController extends MobEntityController {
     public RavagerController() {
-        super(EntityRavagerNPC.class);
+        super(EntityRavagerNPC.class, EntityType.RAVAGER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SalmonController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SalmonController.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SalmonController extends MobEntityController {
     public SalmonController() {
-        super(EntitySalmonNPC.class);
+        super(EntitySalmonNPC.class, EntityType.SALMON);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SheepController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SheepController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SheepController extends MobEntityController {
     public SheepController() {
-        super(EntitySheepNPC.class);
+        super(EntitySheepNPC.class, EntityType.SHEEP);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ShulkerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ShulkerController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ShulkerController extends MobEntityController {
     public ShulkerController() {
-        super(EntityShulkerNPC.class);
+        super(EntityShulkerNPC.class, EntityType.SHULKER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SilverfishController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SilverfishController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SilverfishController extends MobEntityController {
     public SilverfishController() {
-        super(EntitySilverfishNPC.class);
+        super(EntitySilverfishNPC.class, EntityType.SILVERFISH);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SkeletonController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SkeletonController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SkeletonController extends MobEntityController {
     public SkeletonController() {
-        super(EntitySkeletonNPC.class);
+        super(EntitySkeletonNPC.class, EntityType.SKELETON);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SkeletonStrayController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SkeletonStrayController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SkeletonStrayController extends MobEntityController {
     public SkeletonStrayController() {
-        super(EntityStrayNPC.class);
+        super(EntityStrayNPC.class, EntityType.STRAY);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SkeletonWitherController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SkeletonWitherController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SkeletonWitherController extends MobEntityController {
     public SkeletonWitherController() {
-        super(EntitySkeletonWitherNPC.class);
+        super(EntitySkeletonWitherNPC.class, EntityType.WITHER_SKELETON);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SlimeController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SlimeController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SlimeController extends MobEntityController {
     public SlimeController() {
-        super(EntitySlimeNPC.class);
+        super(EntitySlimeNPC.class, EntityType.SLIME);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SnifferController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SnifferController.java
@@ -42,7 +42,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SnifferController extends MobEntityController {
     public SnifferController() {
-        super(EntitySnifferNPC.class);
+        super(EntitySnifferNPC.class, EntityType.SNIFFER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SnowmanController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SnowmanController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SnowmanController extends MobEntityController {
     public SnowmanController() {
-        super(EntitySnowmanNPC.class);
+        super(EntitySnowmanNPC.class, EntityType.SNOW_GOLEM);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SpiderController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SpiderController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SpiderController extends MobEntityController {
     public SpiderController() {
-        super(EntitySpiderNPC.class);
+        super(EntitySpiderNPC.class, EntityType.SPIDER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SquidController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/SquidController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SquidController extends MobEntityController {
     public SquidController() {
-        super(EntitySquidNPC.class);
+        super(EntitySquidNPC.class, EntityType.SQUID);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/StriderController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/StriderController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class StriderController extends MobEntityController {
     public StriderController() {
-        super(EntityStriderNPC.class);
+        super(EntityStriderNPC.class, EntityType.STRIDER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TadpoleController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TadpoleController.java
@@ -44,7 +44,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TadpoleController extends MobEntityController {
     public TadpoleController() {
-        super(EntityTadpoleNPC.class);
+        super(EntityTadpoleNPC.class, EntityType.TADPOLE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TraderLlamaController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TraderLlamaController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TraderLlamaController extends MobEntityController {
     public TraderLlamaController() {
-        super(EntityTraderLlamaNPC.class);
+        super(EntityTraderLlamaNPC.class, EntityType.TRADER_LLAMA);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TropicalFishController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TropicalFishController.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TropicalFishController extends MobEntityController {
     public TropicalFishController() {
-        super(EntityTropicalFishNPC.class);
+        super(EntityTropicalFishNPC.class, EntityType.TROPICAL_FISH);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TurtleController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/TurtleController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TurtleController extends MobEntityController {
     public TurtleController() {
-        super(EntityTurtleNPC.class);
+        super(EntityTurtleNPC.class, EntityType.TURTLE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/VexController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/VexController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class VexController extends MobEntityController {
     public VexController() {
-        super(EntityVexNPC.class);
+        super(EntityVexNPC.class, EntityType.VEX);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/VillagerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/VillagerController.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {
-        super(EntityVillagerNPC.class);
+        super(EntityVillagerNPC.class, EntityType.VILLAGER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/VindicatorController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/VindicatorController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class VindicatorController extends MobEntityController {
     public VindicatorController() {
-        super(EntityVindicatorNPC.class);
+        super(EntityVindicatorNPC.class, EntityType.VINDICATOR);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WanderingTraderController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WanderingTraderController.java
@@ -42,7 +42,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WanderingTraderController extends MobEntityController {
     public WanderingTraderController() {
-        super(EntityWanderingTraderNPC.class);
+        super(EntityWanderingTraderNPC.class, EntityType.WANDERING_TRADER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WardenController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WardenController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WardenController extends MobEntityController {
     public WardenController() {
-        super(EntityWardenNPC.class);
+        super(EntityWardenNPC.class, EntityType.WARDEN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WitchController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WitchController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WitchController extends MobEntityController {
     public WitchController() {
-        super(EntityWitchNPC.class);
+        super(EntityWitchNPC.class, EntityType.WITCH);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WitherController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WitherController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WitherController extends MobEntityController {
     public WitherController() {
-        super(EntityWitherNPC.class);
+        super(EntityWitherNPC.class, EntityType.WITHER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WolfController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/WolfController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WolfController extends MobEntityController {
     public WolfController() {
-        super(EntityWolfNPC.class);
+        super(EntityWolfNPC.class, EntityType.WOLF);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZoglinController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZoglinController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZoglinController extends MobEntityController {
     public ZoglinController() {
-        super(EntityZoglinNPC.class);
+        super(EntityZoglinNPC.class, EntityType.ZOGLIN);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZombieController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZombieController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZombieController extends MobEntityController {
     public ZombieController() {
-        super(EntityZombieNPC.class);
+        super(EntityZombieNPC.class, EntityType.ZOMBIE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZombieHuskController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZombieHuskController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZombieHuskController extends MobEntityController {
     public ZombieHuskController() {
-        super(EntityZombieHuskNPC.class);
+        super(EntityZombieHuskNPC.class, EntityType.HUSK);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZombieVillagerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/ZombieVillagerController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZombieVillagerController extends MobEntityController {
     public ZombieVillagerController() {
-        super(EntityZombieVillagerNPC.class);
+        super(EntityZombieVillagerNPC.class, EntityType.ZOMBIE_VILLAGER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/AreaEffectCloudController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/AreaEffectCloudController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class AreaEffectCloudController extends MobEntityController {
     public AreaEffectCloudController() {
-        super(EntityAreaEffectCloudNPC.class);
+        super(EntityAreaEffectCloudNPC.class, EntityType.AREA_EFFECT_CLOUD);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/BlockDisplayController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/BlockDisplayController.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BlockDisplayController extends MobEntityController {
     public BlockDisplayController() {
-        super(EntityBlockDisplayNPC.class);
+        super(EntityBlockDisplayNPC.class, EntityType.BLOCK_DISPLAY);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/BoatController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/BoatController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BoatController extends MobEntityController {
     public BoatController() {
-        super(EntityBoatNPC.class);
+        super(EntityBoatNPC.class, EntityType.BOAT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ChestBoatController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ChestBoatController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ChestBoatController extends MobEntityController {
     public ChestBoatController() {
-        super(EntityChestBoatNPC.class);
+        super(EntityChestBoatNPC.class, EntityType.CHEST_BOAT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/DragonFireballController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/DragonFireballController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class DragonFireballController extends MobEntityController {
     public DragonFireballController() {
-        super(EntityDragonFireballNPC.class);
+        super(EntityDragonFireballNPC.class, EntityType.DRAGON_FIREBALL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EnderCrystalController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EnderCrystalController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderCrystalController extends MobEntityController {
     public EnderCrystalController() {
-        super(EntityEnderCrystalNPC.class);
+        super(EntityEnderCrystalNPC.class, EntityType.END_CRYSTAL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EnderPearlController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EnderPearlController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderPearlController extends MobEntityController {
     public EnderPearlController() {
-        super(EntityEnderPearlNPC.class);
+        super(EntityEnderPearlNPC.class, EntityType.ENDER_PEARL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EnderSignalController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EnderSignalController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderSignalController extends MobEntityController {
     public EnderSignalController() {
-        super(EntityEnderSignalNPC.class);
+        super(EntityEnderSignalNPC.class, EntityType.EYE_OF_ENDER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EvokerFangsController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/EvokerFangsController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EvokerFangsController extends MobEntityController {
     public EvokerFangsController() {
-        super(EntityEvokerFangsNPC.class);
+        super(EntityEvokerFangsNPC.class, EntityType.EVOKER_FANGS);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ExperienceOrbController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ExperienceOrbController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ExperienceOrbController extends MobEntityController {
     public ExperienceOrbController() {
-        super(EntityExperienceOrbNPC.class);
+        super(EntityExperienceOrbNPC.class, EntityType.EXPERIENCE_ORB);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/FireworkController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/FireworkController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FireworkController extends MobEntityController {
     public FireworkController() {
-        super(EntityFireworkNPC.class);
+        super(EntityFireworkNPC.class, EntityType.FIREWORK_ROCKET);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/FishingHookController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/FishingHookController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FishingHookController extends MobEntityController {
     public FishingHookController() {
-        super(EntityFishingHookNPC.class);
+        super(EntityFishingHookNPC.class, EntityType.FISHING_BOBBER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/GlowItemFrameController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/GlowItemFrameController.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GlowItemFrameController extends MobEntityController {
     public GlowItemFrameController() {
-        super(EntityGlowItemFrameNPC.class);
+        super(EntityGlowItemFrameNPC.class, EntityType.GLOW_ITEM_FRAME);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/InteractionController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/InteractionController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class InteractionController extends MobEntityController {
     public InteractionController() {
-        super(EntityInteractionNPC.class);
+        super(EntityInteractionNPC.class, EntityType.INTERACTION);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ItemDisplayController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ItemDisplayController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ItemDisplayController extends MobEntityController {
     public ItemDisplayController() {
-        super(EntityItemDisplayNPC.class);
+        super(EntityItemDisplayNPC.class, EntityType.ITEM_DISPLAY);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ItemFrameController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ItemFrameController.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ItemFrameController extends MobEntityController {
     public ItemFrameController() {
-        super(EntityItemFrameNPC.class);
+        super(EntityItemFrameNPC.class, EntityType.ITEM_FRAME);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/LargeFireballController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/LargeFireballController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class LargeFireballController extends MobEntityController {
     public LargeFireballController() {
-        super(EntityLargeFireballNPC.class);
+        super(EntityLargeFireballNPC.class, EntityType.FIREBALL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/LeashController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/LeashController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class LeashController extends MobEntityController {
     public LeashController() {
-        super(EntityLeashNPC.class);
+        super(EntityLeashNPC.class, EntityType.LEASH_KNOT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MarkerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MarkerController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MarkerController extends MobEntityController {
     public MarkerController() {
-        super(EntityMarkerNPC.class);
+        super(EntityMarkerNPC.class, EntityType.MARKER);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartChestController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartChestController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartChestController extends MobEntityController {
     public MinecartChestController() {
-        super(EntityMinecartChestNPC.class);
+        super(EntityMinecartChestNPC.class, EntityType.CHEST_MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartCommandController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartCommandController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartCommandController extends MobEntityController {
     public MinecartCommandController() {
-        super(EntityMinecartCommandNPC.class);
+        super(EntityMinecartCommandNPC.class, EntityType.COMMAND_BLOCK_MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartFurnaceController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartFurnaceController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartFurnaceController extends MobEntityController {
     public MinecartFurnaceController() {
-        super(EntityMinecartFurnaceNPC.class);
+        super(EntityMinecartFurnaceNPC.class, EntityType.FURNACE_MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartHopperController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartHopperController.java
@@ -27,7 +27,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartHopperController extends MobEntityController {
     public MinecartHopperController() {
-        super(EntityMinecartHopperNPC.class);
+        super(EntityMinecartHopperNPC.class, EntityType.HOPPER_MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartRideableController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartRideableController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartRideableController extends MobEntityController {
     public MinecartRideableController() {
-        super(EntityMinecartRideableNPC.class);
+        super(EntityMinecartRideableNPC.class, EntityType.MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartSpawnerController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartSpawnerController.java
@@ -27,7 +27,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartSpawnerController extends MobEntityController {
     public MinecartSpawnerController() {
-        super(EntityMinecartSpawnerNPC.class);
+        super(EntityMinecartSpawnerNPC.class, EntityType.SPAWNER_MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartTNTController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/MinecartTNTController.java
@@ -27,7 +27,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartTNTController extends MobEntityController {
     public MinecartTNTController() {
-        super(EntityMinecartTNTNPC.class);
+        super(EntityMinecartTNTNPC.class, EntityType.TNT_MINECART);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/PaintingController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/PaintingController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PaintingController extends MobEntityController {
     public PaintingController() {
-        super(EntityPaintingNPC.class);
+        super(EntityPaintingNPC.class, EntityType.PAINTING);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ShulkerBulletController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ShulkerBulletController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ShulkerBulletController extends MobEntityController {
     public ShulkerBulletController() {
-        super(EntityShulkerBulletNPC.class);
+        super(EntityShulkerBulletNPC.class, EntityType.SHULKER_BULLET);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/SmallFireballController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/SmallFireballController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SmallFireballController extends MobEntityController {
     public SmallFireballController() {
-        super(EntitySmallFireballNPC.class);
+        super(EntitySmallFireballNPC.class, EntityType.SMALL_FIREBALL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/SnowballController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/SnowballController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SnowballController extends MobEntityController {
     public SnowballController() {
-        super(EntitySnowballNPC.class);
+        super(EntitySnowballNPC.class, EntityType.SNOWBALL);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/SpectralArrowController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/SpectralArrowController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SpectralArrowController extends MobEntityController {
     public SpectralArrowController() {
-        super(EntitySpectralArrowNPC.class);
+        super(EntitySpectralArrowNPC.class, EntityType.SPECTRAL_ARROW);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/TNTPrimedController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/TNTPrimedController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TNTPrimedController extends MobEntityController {
     public TNTPrimedController() {
-        super(EntityTNTPrimedNPC.class);
+        super(EntityTNTPrimedNPC.class, EntityType.TNT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/TextDisplayController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/TextDisplayController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TextDisplayController extends MobEntityController {
     public TextDisplayController() {
-        super(EntityTextDisplayNPC.class);
+        super(EntityTextDisplayNPC.class, EntityType.TEXT_DISPLAY);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ThrownExpBottleController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ThrownExpBottleController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ThrownExpBottleController extends MobEntityController {
     public ThrownExpBottleController() {
-        super(EntityThrownExpBottleNPC.class);
+        super(EntityThrownExpBottleNPC.class, EntityType.EXPERIENCE_BOTTLE);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ThrownPotionController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ThrownPotionController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ThrownPotionController extends MobEntityController {
     public ThrownPotionController() {
-        super(EntityThrownPotionNPC.class);
+        super(EntityThrownPotionNPC.class, EntityType.POTION);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ThrownTridentController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/ThrownTridentController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ThrownTridentController extends MobEntityController {
     public ThrownTridentController() {
-        super(EntityThrownTridentNPC.class);
+        super(EntityThrownTridentNPC.class, EntityType.TRIDENT);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/TippedArrowController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/TippedArrowController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TippedArrowController extends MobEntityController {
     public TippedArrowController() {
-        super(EntityTippedArrowNPC.class);
+        super(EntityTippedArrowNPC.class, EntityType.ARROW);
     }
 
     @Override

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/WitherSkullController.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/nonliving/WitherSkullController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WitherSkullController extends MobEntityController {
     public WitherSkullController() {
-        super(EntityWitherSkullNPC.class);
+        super(EntityWitherSkullNPC.class, EntityType.WITHER_SKULL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/AllayController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/AllayController.java
@@ -43,7 +43,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class AllayController extends MobEntityController {
     public AllayController() {
-        super(EntityAllayNPC.class);
+        super(EntityAllayNPC.class, EntityType.ALLAY);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ArmadilloController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ArmadilloController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ArmadilloController extends MobEntityController {
     public ArmadilloController() {
-        super(EntityArmadilloNPC.class);
+        super(EntityArmadilloNPC.class, EntityType.ARMADILLO);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ArmorStandController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ArmorStandController.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ArmorStandController extends MobEntityController {
     public ArmorStandController() {
-        super(EntityArmorStandNPC.class);
+        super(EntityArmorStandNPC.class, EntityType.ARMOR_STAND);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/AxolotlController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/AxolotlController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class AxolotlController extends MobEntityController {
     public AxolotlController() {
-        super(EntityAxolotlNPC.class);
+        super(EntityAxolotlNPC.class, EntityType.AXOLOTL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BatController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BatController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BatController extends MobEntityController {
     public BatController() {
-        super(EntityBatNPC.class);
+        super(EntityBatNPC.class, EntityType.BAT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BeeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BeeController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BeeController extends MobEntityController {
     public BeeController() {
-        super(EntityBeeNPC.class);
+        super(EntityBeeNPC.class, EntityType.BEE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BlazeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BlazeController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BlazeController extends MobEntityController {
     public BlazeController() {
-        super(EntityBlazeNPC.class);
+        super(EntityBlazeNPC.class, EntityType.BLAZE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BoggedController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BoggedController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BoggedController extends MobEntityController {
     public BoggedController() {
-        super(EntityBoggedNPC.class);
+        super(EntityBoggedNPC.class, EntityType.BOGGED);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BreezeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/BreezeController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BreezeController extends MobEntityController {
     public BreezeController() {
-        super(EntityBreezeNPC.class);
+        super(EntityBreezeNPC.class, EntityType.BREEZE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CamelController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CamelController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CamelController extends MobEntityController {
     public CamelController() {
-        super(EntityCamelNPC.class);
+        super(EntityCamelNPC.class, EntityType.CAMEL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CatController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CatController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CatController extends MobEntityController {
     public CatController() {
-        super(EntityCatNPC.class);
+        super(EntityCatNPC.class, EntityType.CAT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CaveSpiderController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CaveSpiderController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CaveSpiderController extends MobEntityController {
     public CaveSpiderController() {
-        super(EntityCaveSpiderNPC.class);
+        super(EntityCaveSpiderNPC.class, EntityType.CAVE_SPIDER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ChickenController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ChickenController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ChickenController extends MobEntityController {
     public ChickenController() {
-        super(EntityChickenNPC.class);
+        super(EntityChickenNPC.class, EntityType.CHICKEN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CodController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CodController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CodController extends MobEntityController {
     public CodController() {
-        super(EntityCodNPC.class);
+        super(EntityCodNPC.class, EntityType.COD);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CowController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CowController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CowController extends MobEntityController {
     public CowController() {
-        super(EntityCowNPC.class);
+        super(EntityCowNPC.class, EntityType.COW);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CreeperController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/CreeperController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class CreeperController extends MobEntityController {
     public CreeperController() {
-        super(EntityCreeperNPC.class);
+        super(EntityCreeperNPC.class, EntityType.CREEPER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/DolphinController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/DolphinController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class DolphinController extends MobEntityController {
     public DolphinController() {
-        super(EntityDolphinNPC.class);
+        super(EntityDolphinNPC.class, EntityType.DOLPHIN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/DrownedController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/DrownedController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class DrownedController extends MobEntityController {
     public DrownedController() {
-        super(EntityDrownedNPC.class);
+        super(EntityDrownedNPC.class, EntityType.DROWNED);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EnderDragonController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EnderDragonController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderDragonController extends MobEntityController {
     public EnderDragonController() {
-        super(EntityEnderDragonNPC.class);
+        super(EntityEnderDragonNPC.class, EntityType.ENDER_DRAGON);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EndermanController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EndermanController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EndermanController extends MobEntityController {
     public EndermanController() {
-        super(EntityEndermanNPC.class);
+        super(EntityEndermanNPC.class, EntityType.ENDERMAN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EndermiteController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EndermiteController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EndermiteController extends MobEntityController {
     public EndermiteController() {
-        super(EntityEndermiteNPC.class);
+        super(EntityEndermiteNPC.class, EntityType.ENDERMITE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EvokerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EvokerController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EvokerController extends MobEntityController {
     public EvokerController() {
-        super(EntityEvokerNPC.class);
+        super(EntityEvokerNPC.class, EntityType.EVOKER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/FoxController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/FoxController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FoxController extends MobEntityController {
     public FoxController() {
-        super(EntityFoxNPC.class);
+        super(EntityFoxNPC.class, EntityType.FOX);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/FrogController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/FrogController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FrogController extends MobEntityController {
     public FrogController() {
-        super(EntityFrogNPC.class);
+        super(EntityFrogNPC.class, EntityType.FROG);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GhastController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GhastController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GhastController extends MobEntityController {
     public GhastController() {
-        super(EntityGhastNPC.class);
+        super(EntityGhastNPC.class, EntityType.GHAST);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GiantController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GiantController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GiantController extends MobEntityController {
     public GiantController() {
-        super(EntityGiantNPC.class);
+        super(EntityGiantNPC.class, EntityType.GIANT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GlowSquidController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GlowSquidController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GlowSquidController extends MobEntityController {
     public GlowSquidController() {
-        super(EntityGlowSquidNPC.class);
+        super(EntityGlowSquidNPC.class, EntityType.GLOW_SQUID);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GoatController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GoatController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GoatController extends MobEntityController {
     public GoatController() {
-        super(EntityGoatNPC.class);
+        super(EntityGoatNPC.class, EntityType.GOAT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GuardianController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GuardianController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GuardianController extends MobEntityController {
     public GuardianController() {
-        super(EntityGuardianNPC.class);
+        super(EntityGuardianNPC.class, EntityType.GUARDIAN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GuardianElderController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/GuardianElderController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GuardianElderController extends MobEntityController {
     public GuardianElderController() {
-        super(EntityGuardianElderNPC.class);
+        super(EntityGuardianElderNPC.class, EntityType.ELDER_GUARDIAN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HoglinController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HoglinController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HoglinController extends MobEntityController {
     public HoglinController() {
-        super(EntityHoglinNPC.class);
+        super(EntityHoglinNPC.class, EntityType.HOGLIN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseController extends MobEntityController {
     public HorseController() {
-        super(EntityHorseNPC.class);
+        super(EntityHorseNPC.class, EntityType.HORSE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseDonkeyController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseDonkeyController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseDonkeyController extends MobEntityController {
     public HorseDonkeyController() {
-        super(EntityHorseDonkeyNPC.class);
+        super(EntityHorseDonkeyNPC.class, EntityType.DONKEY);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseMuleController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseMuleController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseMuleController extends MobEntityController {
     public HorseMuleController() {
-        super(EntityHorseMuleNPC.class);
+        super(EntityHorseMuleNPC.class, EntityType.MULE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseSkeletonController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseSkeletonController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseSkeletonController extends MobEntityController {
     public HorseSkeletonController() {
-        super(EntityHorseSkeletonNPC.class);
+        super(EntityHorseSkeletonNPC.class, EntityType.SKELETON);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseZombieController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/HorseZombieController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class HorseZombieController extends MobEntityController {
     public HorseZombieController() {
-        super(EntityHorseZombieNPC.class);
+        super(EntityHorseZombieNPC.class, EntityType.ZOMBIE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/IllusionerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/IllusionerController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class IllusionerController extends MobEntityController {
     public IllusionerController() {
-        super(EntityIllusionerNPC.class);
+        super(EntityIllusionerNPC.class, EntityType.ILLUSIONER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/IronGolemController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/IronGolemController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class IronGolemController extends MobEntityController {
     public IronGolemController() {
-        super(EntityIronGolemNPC.class);
+        super(EntityIronGolemNPC.class, EntityType.IRON_GOLEM);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/LlamaController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/LlamaController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class LlamaController extends MobEntityController {
     public LlamaController() {
-        super(EntityLlamaNPC.class);
+        super(EntityLlamaNPC.class, EntityType.LLAMA);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/MagmaCubeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/MagmaCubeController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MagmaCubeController extends MobEntityController {
     public MagmaCubeController() {
-        super(EntityMagmaCubeNPC.class);
+        super(EntityMagmaCubeNPC.class, EntityType.MAGMA_CUBE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/MobEntityController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/MobEntityController.java
@@ -24,8 +24,8 @@ import net.minecraft.world.level.Level;
 public abstract class MobEntityController extends AbstractEntityController {
     private final Class<?> clazz;
 
-    protected MobEntityController(Class<?> clazz) {
-        NMS.registerEntityClass(clazz, NMSImpl.getEntityType(clazz));
+    protected MobEntityController(Class<?> clazz, EntityType<?> type) {
+        NMS.registerEntityClass(clazz, type);
         this.clazz = clazz;
     }
 

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/MushroomCowController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/MushroomCowController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MushroomCowController extends MobEntityController {
     public MushroomCowController() {
-        super(EntityMushroomCowNPC.class);
+        super(EntityMushroomCowNPC.class, EntityType.MOOSHROOM);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/OcelotController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/OcelotController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class OcelotController extends MobEntityController {
     public OcelotController() {
-        super(EntityOcelotNPC.class);
+        super(EntityOcelotNPC.class, EntityType.OCELOT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PandaController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PandaController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PandaController extends MobEntityController {
     public PandaController() {
-        super(EntityPandaNPC.class);
+        super(EntityPandaNPC.class, EntityType.PANDA);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ParrotController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ParrotController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ParrotController extends MobEntityController {
     public ParrotController() {
-        super(EntityParrotNPC.class);
+        super(EntityParrotNPC.class, EntityType.PARROT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PhantomController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PhantomController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PhantomController extends MobEntityController {
     public PhantomController() {
-        super(EntityPhantomNPC.class);
+        super(EntityPhantomNPC.class, EntityType.PHANTOM);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PigController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PigController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PigController extends MobEntityController {
     public PigController() {
-        super(EntityPigNPC.class);
+        super(EntityPigNPC.class, EntityType.PIG);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PigZombieController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PigZombieController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PigZombieController extends MobEntityController {
     public PigZombieController() {
-        super(EntityPigZombieNPC.class);
+        super(EntityPigZombieNPC.class, EntityType.ZOMBIFIED_PIGLIN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PiglinBruteController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PiglinBruteController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PiglinBruteController extends MobEntityController {
     public PiglinBruteController() {
-        super(EntityPiglinBruteNPC.class);
+        super(EntityPiglinBruteNPC.class, EntityType.PIGLIN_BRUTE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PiglinController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PiglinController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PiglinController extends MobEntityController {
     public PiglinController() {
-        super(EntityPiglinNPC.class);
+        super(EntityPiglinNPC.class, EntityType.PIGLIN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PillagerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PillagerController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PillagerController extends MobEntityController {
     public PillagerController() {
-        super(EntityPillagerNPC.class);
+        super(EntityPillagerNPC.class, EntityType.PILLAGER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PolarBearController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PolarBearController.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PolarBearController extends MobEntityController {
     public PolarBearController() {
-        super(EntityPolarBearNPC.class);
+        super(EntityPolarBearNPC.class, EntityType.POLAR_BEAR);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PufferFishController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/PufferFishController.java
@@ -44,7 +44,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PufferFishController extends MobEntityController {
     public PufferFishController() {
-        super(EntityPufferFishNPC.class);
+        super(EntityPufferFishNPC.class, EntityType.PUFFERFISH);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/RabbitController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/RabbitController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class RabbitController extends MobEntityController {
     public RabbitController() {
-        super(EntityRabbitNPC.class);
+        super(EntityRabbitNPC.class, EntityType.RABBIT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/RavagerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/RavagerController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class RavagerController extends MobEntityController {
     public RavagerController() {
-        super(EntityRavagerNPC.class);
+        super(EntityRavagerNPC.class, EntityType.RAVAGER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SalmonController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SalmonController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SalmonController extends MobEntityController {
     public SalmonController() {
-        super(EntitySalmonNPC.class);
+        super(EntitySalmonNPC.class, EntityType.SALMON);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SheepController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SheepController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SheepController extends MobEntityController {
     public SheepController() {
-        super(EntitySheepNPC.class);
+        super(EntitySheepNPC.class, EntityType.SHEEP);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ShulkerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ShulkerController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ShulkerController extends MobEntityController {
     public ShulkerController() {
-        super(EntityShulkerNPC.class);
+        super(EntityShulkerNPC.class, EntityType.SHULKER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SilverfishController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SilverfishController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SilverfishController extends MobEntityController {
     public SilverfishController() {
-        super(EntitySilverfishNPC.class);
+        super(EntitySilverfishNPC.class, EntityType.SILVERFISH);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SkeletonController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SkeletonController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SkeletonController extends MobEntityController {
     public SkeletonController() {
-        super(EntitySkeletonNPC.class);
+        super(EntitySkeletonNPC.class, EntityType.SKELETON);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SkeletonStrayController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SkeletonStrayController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SkeletonStrayController extends MobEntityController {
     public SkeletonStrayController() {
-        super(EntityStrayNPC.class);
+        super(EntityStrayNPC.class, EntityType.STRAY);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SkeletonWitherController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SkeletonWitherController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SkeletonWitherController extends MobEntityController {
     public SkeletonWitherController() {
-        super(EntitySkeletonWitherNPC.class);
+        super(EntitySkeletonWitherNPC.class, EntityType.WITHER_SKELETON);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SlimeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SlimeController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SlimeController extends MobEntityController {
     public SlimeController() {
-        super(EntitySlimeNPC.class);
+        super(EntitySlimeNPC.class, EntityType.SLIME);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SnifferController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SnifferController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SnifferController extends MobEntityController {
     public SnifferController() {
-        super(EntitySnifferNPC.class);
+        super(EntitySnifferNPC.class, EntityType.SNIFFER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SnowmanController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SnowmanController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SnowmanController extends MobEntityController {
     public SnowmanController() {
-        super(EntitySnowmanNPC.class);
+        super(EntitySnowmanNPC.class, EntityType.SNOW_GOLEM);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SpiderController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SpiderController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SpiderController extends MobEntityController {
     public SpiderController() {
-        super(EntitySpiderNPC.class);
+        super(EntitySpiderNPC.class, EntityType.SPIDER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SquidController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/SquidController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SquidController extends MobEntityController {
     public SquidController() {
-        super(EntitySquidNPC.class);
+        super(EntitySquidNPC.class, EntityType.SQUID);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/StriderController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/StriderController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class StriderController extends MobEntityController {
     public StriderController() {
-        super(EntityStriderNPC.class);
+        super(EntityStriderNPC.class, EntityType.STRIDER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TadpoleController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TadpoleController.java
@@ -42,7 +42,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TadpoleController extends MobEntityController {
     public TadpoleController() {
-        super(EntityTadpoleNPC.class);
+        super(EntityTadpoleNPC.class, EntityType.TADPOLE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TraderLlamaController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TraderLlamaController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TraderLlamaController extends MobEntityController {
     public TraderLlamaController() {
-        super(EntityTraderLlamaNPC.class);
+        super(EntityTraderLlamaNPC.class, EntityType.TRADER_LLAMA);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TropicalFishController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TropicalFishController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TropicalFishController extends MobEntityController {
     public TropicalFishController() {
-        super(EntityTropicalFishNPC.class);
+        super(EntityTropicalFishNPC.class, EntityType.TROPICAL_FISH);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TurtleController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/TurtleController.java
@@ -38,7 +38,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TurtleController extends MobEntityController {
     public TurtleController() {
-        super(EntityTurtleNPC.class);
+        super(EntityTurtleNPC.class, EntityType.TURTLE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/VexController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/VexController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class VexController extends MobEntityController {
     public VexController() {
-        super(EntityVexNPC.class);
+        super(EntityVexNPC.class, EntityType.VEX);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/VillagerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/VillagerController.java
@@ -41,7 +41,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class VillagerController extends MobEntityController {
     public VillagerController() {
-        super(EntityVillagerNPC.class);
+        super(EntityVillagerNPC.class, EntityType.VILLAGER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/VindicatorController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/VindicatorController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class VindicatorController extends MobEntityController {
     public VindicatorController() {
-        super(EntityVindicatorNPC.class);
+        super(EntityVindicatorNPC.class, EntityType.VINDICATOR);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WanderingTraderController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WanderingTraderController.java
@@ -40,7 +40,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WanderingTraderController extends MobEntityController {
     public WanderingTraderController() {
-        super(EntityWanderingTraderNPC.class);
+        super(EntityWanderingTraderNPC.class, EntityType.WANDERING_TRADER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WardenController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WardenController.java
@@ -36,7 +36,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WardenController extends MobEntityController {
     public WardenController() {
-        super(EntityWardenNPC.class);
+        super(EntityWardenNPC.class, EntityType.WARDEN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WitchController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WitchController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WitchController extends MobEntityController {
     public WitchController() {
-        super(EntityWitchNPC.class);
+        super(EntityWitchNPC.class, EntityType.WITCH);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WitherController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WitherController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WitherController extends MobEntityController {
     public WitherController() {
-        super(EntityWitherNPC.class);
+        super(EntityWitherNPC.class, EntityType.WITHER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WolfController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/WolfController.java
@@ -37,7 +37,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WolfController extends MobEntityController {
     public WolfController() {
-        super(EntityWolfNPC.class);
+        super(EntityWolfNPC.class, EntityType.WOLF);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZoglinController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZoglinController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZoglinController extends MobEntityController {
     public ZoglinController() {
-        super(EntityZoglinNPC.class);
+        super(EntityZoglinNPC.class, EntityType.ZOGLIN);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZombieController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZombieController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZombieController extends MobEntityController {
     public ZombieController() {
-        super(EntityZombieNPC.class);
+        super(EntityZombieNPC.class, EntityType.ZOMBIE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZombieHuskController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZombieHuskController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZombieHuskController extends MobEntityController {
     public ZombieHuskController() {
-        super(EntityZombieHuskNPC.class);
+        super(EntityZombieHuskNPC.class, EntityType.HUSK);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZombieVillagerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/ZombieVillagerController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ZombieVillagerController extends MobEntityController {
     public ZombieVillagerController() {
-        super(EntityZombieVillagerNPC.class);
+        super(EntityZombieVillagerNPC.class, EntityType.ZOMBIE_VILLAGER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/AreaEffectCloudController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/AreaEffectCloudController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class AreaEffectCloudController extends MobEntityController {
     public AreaEffectCloudController() {
-        super(EntityAreaEffectCloudNPC.class);
+        super(EntityAreaEffectCloudNPC.class, EntityType.AREA_EFFECT_CLOUD);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/BlockDisplayController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/BlockDisplayController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BlockDisplayController extends MobEntityController {
     public BlockDisplayController() {
-        super(EntityBlockDisplayNPC.class);
+        super(EntityBlockDisplayNPC.class, EntityType.BLOCK_DISPLAY);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/BoatController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/BoatController.java
@@ -34,7 +34,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BoatController extends MobEntityController {
     public BoatController() {
-        super(EntityBoatNPC.class);
+        super(EntityBoatNPC.class, EntityType.BOAT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/BreezeWindChargeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/BreezeWindChargeController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class BreezeWindChargeController extends MobEntityController {
     public BreezeWindChargeController() {
-        super(EntityBreezeWindChargeNPC.class);
+        super(EntityBreezeWindChargeNPC.class, EntityType.BREEZE_WIND_CHARGE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ChestBoatController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ChestBoatController.java
@@ -35,7 +35,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ChestBoatController extends MobEntityController {
     public ChestBoatController() {
-        super(EntityChestBoatNPC.class);
+        super(EntityChestBoatNPC.class, EntityType.CHEST_BOAT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/DragonFireballController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/DragonFireballController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class DragonFireballController extends MobEntityController {
     public DragonFireballController() {
-        super(EntityDragonFireballNPC.class);
+        super(EntityDragonFireballNPC.class, EntityType.DRAGON_FIREBALL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EnderCrystalController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EnderCrystalController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderCrystalController extends MobEntityController {
     public EnderCrystalController() {
-        super(EntityEnderCrystalNPC.class);
+        super(EntityEnderCrystalNPC.class, EntityType.END_CRYSTAL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EnderPearlController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EnderPearlController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EnderPearlController extends MobEntityController {
     public EnderPearlController() {
-        super(EntityEnderPearlNPC.class);
+        super(EntityEnderPearlNPC.class, EntityType.ENDER_PEARL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EvokerFangsController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EvokerFangsController.java
@@ -33,7 +33,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EvokerFangsController extends MobEntityController {
     public EvokerFangsController() {
-        super(EntityEvokerFangsNPC.class);
+        super(EntityEvokerFangsNPC.class, EntityType.EVOKER_FANGS);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ExperienceOrbController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ExperienceOrbController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ExperienceOrbController extends MobEntityController {
     public ExperienceOrbController() {
-        super(EntityExperienceOrbNPC.class);
+        super(EntityExperienceOrbNPC.class, EntityType.EXPERIENCE_ORB);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EyeOfEnderController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/EyeOfEnderController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class EyeOfEnderController extends MobEntityController {
     public EyeOfEnderController() {
-        super(EntityEnderSignalNPC.class);
+        super(EntityEnderSignalNPC.class, EntityType.EYE_OF_ENDER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/FireworkController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/FireworkController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FireworkController extends MobEntityController {
     public FireworkController() {
-        super(EntityFireworkNPC.class);
+        super(EntityFireworkNPC.class, EntityType.FIREWORK_ROCKET);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/FishingHookController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/FishingHookController.java
@@ -39,7 +39,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class FishingHookController extends MobEntityController {
     public FishingHookController() {
-        super(EntityFishingHookNPC.class);
+        super(EntityFishingHookNPC.class, EntityType.FISHING_BOBBER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/GlowItemFrameController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/GlowItemFrameController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class GlowItemFrameController extends MobEntityController {
     public GlowItemFrameController() {
-        super(EntityGlowItemFrameNPC.class);
+        super(EntityGlowItemFrameNPC.class, EntityType.GLOW_ITEM_FRAME);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/InteractionController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/InteractionController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class InteractionController extends MobEntityController {
     public InteractionController() {
-        super(EntityInteractionNPC.class);
+        super(EntityInteractionNPC.class, EntityType.INTERACTION);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ItemDisplayController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ItemDisplayController.java
@@ -32,7 +32,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ItemDisplayController extends MobEntityController {
     public ItemDisplayController() {
-        super(EntityItemDisplayNPC.class);
+        super(EntityItemDisplayNPC.class, EntityType.ITEM_DISPLAY);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ItemFrameController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ItemFrameController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ItemFrameController extends MobEntityController {
     public ItemFrameController() {
-        super(EntityItemFrameNPC.class);
+        super(EntityItemFrameNPC.class, EntityType.ITEM_FRAME);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/LargeFireballController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/LargeFireballController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class LargeFireballController extends MobEntityController {
     public LargeFireballController() {
-        super(EntityLargeFireballNPC.class);
+        super(EntityLargeFireballNPC.class, EntityType.FIREBALL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/LeashController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/LeashController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class LeashController extends MobEntityController {
     public LeashController() {
-        super(EntityLeashNPC.class);
+        super(EntityLeashNPC.class, EntityType.LEASH_KNOT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MarkerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MarkerController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MarkerController extends MobEntityController {
     public MarkerController() {
-        super(EntityMarkerNPC.class);
+        super(EntityMarkerNPC.class, EntityType.MARKER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartChestController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartChestController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartChestController extends MobEntityController {
     public MinecartChestController() {
-        super(EntityMinecartChestNPC.class);
+        super(EntityMinecartChestNPC.class, EntityType.CHEST_MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartCommandController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartCommandController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartCommandController extends MobEntityController {
     public MinecartCommandController() {
-        super(EntityMinecartCommandNPC.class);
+        super(EntityMinecartCommandNPC.class, EntityType.COMMAND_BLOCK_MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartFurnaceController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartFurnaceController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartFurnaceController extends MobEntityController {
     public MinecartFurnaceController() {
-        super(EntityMinecartFurnaceNPC.class);
+        super(EntityMinecartFurnaceNPC.class, EntityType.FURNACE_MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartHopperController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartHopperController.java
@@ -25,7 +25,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartHopperController extends MobEntityController {
     public MinecartHopperController() {
-        super(EntityMinecartHopperNPC.class);
+        super(EntityMinecartHopperNPC.class, EntityType.HOPPER_MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartRideableController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartRideableController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartRideableController extends MobEntityController {
     public MinecartRideableController() {
-        super(EntityMinecartRideableNPC.class);
+        super(EntityMinecartRideableNPC.class, EntityType.MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartSpawnerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartSpawnerController.java
@@ -25,7 +25,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartSpawnerController extends MobEntityController {
     public MinecartSpawnerController() {
-        super(EntityMinecartSpawnerNPC.class);
+        super(EntityMinecartSpawnerNPC.class, EntityType.SPAWNER_MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartTNTController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/MinecartTNTController.java
@@ -25,7 +25,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class MinecartTNTController extends MobEntityController {
     public MinecartTNTController() {
-        super(EntityMinecartTNTNPC.class);
+        super(EntityMinecartTNTNPC.class, EntityType.TNT_MINECART);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/OminousItemSpawnerController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/OminousItemSpawnerController.java
@@ -31,7 +31,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class OminousItemSpawnerController extends MobEntityController {
     public OminousItemSpawnerController() {
-        super(EntityOminousItemSpawnerNPC.class);
+        super(EntityOminousItemSpawnerNPC.class, EntityType.OMINOUS_ITEM_SPAWNER);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/PaintingController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/PaintingController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class PaintingController extends MobEntityController {
     public PaintingController() {
-        super(EntityPaintingNPC.class);
+        super(EntityPaintingNPC.class, EntityType.PAINTING);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ShulkerBulletController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ShulkerBulletController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ShulkerBulletController extends MobEntityController {
     public ShulkerBulletController() {
-        super(EntityShulkerBulletNPC.class);
+        super(EntityShulkerBulletNPC.class, EntityType.SHULKER_BULLET);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/SmallFireballController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/SmallFireballController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SmallFireballController extends MobEntityController {
     public SmallFireballController() {
-        super(EntitySmallFireballNPC.class);
+        super(EntitySmallFireballNPC.class, EntityType.SMALL_FIREBALL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/SnowballController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/SnowballController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SnowballController extends MobEntityController {
     public SnowballController() {
-        super(EntitySnowballNPC.class);
+        super(EntitySnowballNPC.class, EntityType.SNOWBALL);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/SpectralArrowController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/SpectralArrowController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class SpectralArrowController extends MobEntityController {
     public SpectralArrowController() {
-        super(EntitySpectralArrowNPC.class);
+        super(EntitySpectralArrowNPC.class, EntityType.SPECTRAL_ARROW);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/TNTPrimedController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/TNTPrimedController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TNTPrimedController extends MobEntityController {
     public TNTPrimedController() {
-        super(EntityTNTPrimedNPC.class);
+        super(EntityTNTPrimedNPC.class, EntityType.TNT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/TextDisplayController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/TextDisplayController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TextDisplayController extends MobEntityController {
     public TextDisplayController() {
-        super(EntityTextDisplayNPC.class);
+        super(EntityTextDisplayNPC.class, EntityType.TEXT_DISPLAY);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ThrownExpBottleController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ThrownExpBottleController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ThrownExpBottleController extends MobEntityController {
     public ThrownExpBottleController() {
-        super(EntityThrownExpBottleNPC.class);
+        super(EntityThrownExpBottleNPC.class, EntityType.EXPERIENCE_BOTTLE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ThrownPotionController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ThrownPotionController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ThrownPotionController extends MobEntityController {
     public ThrownPotionController() {
-        super(EntityThrownPotionNPC.class);
+        super(EntityThrownPotionNPC.class, EntityType.POTION);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ThrownTridentController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/ThrownTridentController.java
@@ -30,7 +30,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class ThrownTridentController extends MobEntityController {
     public ThrownTridentController() {
-        super(EntityThrownTridentNPC.class);
+        super(EntityThrownTridentNPC.class, EntityType.TRIDENT);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/TippedArrowController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/TippedArrowController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class TippedArrowController extends MobEntityController {
     public TippedArrowController() {
-        super(EntityTippedArrowNPC.class);
+        super(EntityTippedArrowNPC.class, EntityType.ARROW);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/WindChargeController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/WindChargeController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WindChargeController extends MobEntityController {
     public WindChargeController() {
-        super(EntityWindChargeNPC.class);
+        super(EntityWindChargeNPC.class, EntityType.WIND_CHARGE);
     }
 
     @Override

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/WitherSkullController.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/nonliving/WitherSkullController.java
@@ -29,7 +29,7 @@ import net.minecraft.world.phys.Vec3;
 
 public class WitherSkullController extends MobEntityController {
     public WitherSkullController() {
-        super(EntityWitherSkullNPC.class);
+        super(EntityWitherSkullNPC.class, EntityType.WITHER_SKULL);
     }
 
     @Override


### PR DESCRIPTION
Already reported on Discord [there](https://discord.com/channels/315163488085475337/1299961868214992906).

Fixed this issue for 1.19 and 1.20. Other unsupported modules are not considered, but should be checked as well.
Unfortunately due to the changed boat type API in newer MC I can't launch a 1.18 server with current version of Citizens,
 so checks on more older versions are ignored.

Original post on Discord:
Today I'm just looking at the partially-finished boundingbox trait improvement code and tried to use it. However I failed to apply the trait as the plugin gives NPE and say nothing more.
I was just thinking if it is just fault from new code. But after got noticed that interaction uses mob controller so I tried to create some mob NPC but all of them are unable to be created.
Player NPCs still work well. So I think that's why no recent issue related to this.
Log there: https://paste.denizenscript.com/View/127565

Source tracing:
Let's begin with MobController, where the issue happens. When its instance is constructed, it will register itself to NMS bridge for further use. It seems to be right but NMSImpl.getEntityType method always return null.
And after some simple research on it, I've found that the entity type map it uses only got updated while class searching on it was done and succeeded, and the map is initially empty.
So what does it mean? We are attempting to register the entity class using null as we never searched it before and will never succeed. In a simply way to describe this, we're using unknown result from future for now.

Possible solution:
Sync the register code change from 1.21 submodule as it is correct.