### PR TITLE
fix: search attributes using different key for backwards compatibility

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -400,7 +400,7 @@ public class CitizensNPC extends AbstractNPC {
 
                     if (type == EntityType.PLAYER || Util.isHorse(type)) {
                         if (SUPPORT_ATTRIBUTES && !hasTrait(AttributeTrait.class) || !getTrait(AttributeTrait.class)
-                                .hasAttribute(Registry.ATTRIBUTE.get(SpigotUtil.getKey("step_height")))) {
+                                .hasAttribute(NMS.getRegistryValue(Registry.ATTRIBUTE, "generic.step_height", "step_height"))) {
                             NMS.setStepHeight(entity, 1);
                         }
                     }

--- a/main/src/main/java/net/citizensnpcs/trait/HologramTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/HologramTrait.java
@@ -916,7 +916,7 @@ public class HologramTrait extends Trait {
             }
             if (SpigotUtil.getVersion()[1] >= 21 && base.getEntity() instanceof LivingEntity) {
                 AttributeInstance inst = ((LivingEntity) base.getEntity())
-                        .getAttribute(Registry.ATTRIBUTE.get(SpigotUtil.getKey("scale")));
+                        .getAttribute(NMS.getRegistryValue(Registry.ATTRIBUTE, "generic.scale", "scale"));
                 if (inst != null) {
                     Transformation tf = disp.getTransformation();
                     tf.getScale().set(inst.getValue());

--- a/main/src/main/java/net/citizensnpcs/trait/ScaledMaxHealthTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScaledMaxHealthTrait.java
@@ -41,7 +41,7 @@ public class ScaledMaxHealthTrait extends Trait {
     public void onSpawn() {
         if (maxHealth != null && npc.getEntity() instanceof LivingEntity) {
             if (SUPPORTS_ATTRIBUTES) {
-                ((LivingEntity) npc.getEntity()).getAttribute(Registry.ATTRIBUTE.get(SpigotUtil.getKey("max_health")))
+                ((LivingEntity) npc.getEntity()).getAttribute(NMS.getRegistryValue(Registry.ATTRIBUTE, "generic.max_health", "max_health"))
                         .setBaseValue(Math.min(MAX_VALUE, maxHealth));
             } else {
                 ((LivingEntity) npc.getEntity()).setMaxHealth(maxHealth);

--- a/main/src/main/java/net/citizensnpcs/trait/versioned/BossBarTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/versioned/BossBarTrait.java
@@ -143,7 +143,7 @@ public class BossBarTrait extends Trait {
                     LivingEntity entity = (LivingEntity) npc.getEntity();
                     double maxHealth = entity.getMaxHealth();
                     if (SUPPORT_ATTRIBUTES) {
-                        maxHealth = entity.getAttribute(Registry.ATTRIBUTE.get(SpigotUtil.getKey("max_health")))
+                        maxHealth = entity.getAttribute(NMS.getRegistryValue(Registry.ATTRIBUTE, "generic.max_health", "max_health"))
                                 .getValue();
                     }
                     bar.setProgress(entity.getHealth() / maxHealth);

--- a/main/src/main/java/net/citizensnpcs/util/NMS.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMS.java
@@ -131,7 +131,7 @@ public class NMS {
             return;
         if (SUPPORTS_ATTRIBUTABLE && npc.getEntity() instanceof Attributable) {
             AttributeInstance attribute = ((Attributable) npc.getEntity())
-                    .getAttribute(Registry.ATTRIBUTE.get(SpigotUtil.getKey("knockback_resistance")));
+                    .getAttribute(NMS.getRegistryValue(Registry.ATTRIBUTE, "generic.knockback_resistance", "knockback_resistance"));
             if (attribute != null) {
                 strength *= 1 - attribute.getValue();
             }
@@ -595,6 +595,17 @@ public class NMS {
 
     public static GameProfile getProfile(SkullMeta meta) {
         return BRIDGE.getProfile(meta);
+    }
+
+    public static <T extends Keyed> T getRegistryValue(Registry<T> registry, String... keyCandidates) {
+        for (String keyCandidate : keyCandidates) {
+            final NamespacedKey key = SpigotUtil.getKey(keyCandidate);
+            final T value = registry.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
     }
 
     public static float getRidingHeightOffset(Entity entity, Entity mount) {


### PR DESCRIPTION
Attribute keys also got changed in 1.21.3 API, but these name are invalid in older API like 1.20.6.