### PR TITLE
Allow subdirectories in skins folder

### DIFF
--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -2,6 +2,7 @@ package net.citizensnpcs.commands;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -3006,9 +3007,13 @@ public class NPCCommands {
     }
 
     private boolean isInDirectory(File file, File directory) {
-        Path filePath = Paths.get(file.toURI()).normalize();
-        Path directoryPath = Paths.get(directory.toURI()).normalize();
-        return filePath.startsWith(directoryPath);
+        try {
+            Path filePath = Paths.get(file.toURI()).toRealPath().normalize();
+            Path directoryPath = Paths.get(directory.toURI()).toRealPath().normalize();
+            return filePath.startsWith(directoryPath);
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     @Command(


### PR DESCRIPTION
This PRs modifies the logic so skins can be placed in sub directories in the skins directory.

This could be handy for large servers with many NPC skins.