### PR TITLE
fix: rework #3195

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -548,13 +548,17 @@ public class CitizensNPC extends AbstractNPC {
         }
     }
 
-    private void updateCustomName() {
-        if (getEntity() == null)
+    @Override
+    public void updateCustomName() {
+        final Entity entity = getEntity();
+        if (entity == null)
             return;
         if (coloredNameComponentCache != null) {
-            NMS.setCustomName(getEntity(), coloredNameComponentCache, coloredNameStringCache);
+            NMS.setCustomName(entity, null, null);
+            NMS.setCustomName(entity, coloredNameComponentCache, coloredNameStringCache);
         } else {
-            getEntity().setCustomName(getFullName());
+            entity.setCustomName(null);
+            entity.setCustomName(getFullName());
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/trait/HologramTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/HologramTrait.java
@@ -868,10 +868,11 @@ public class HologramTrait extends Trait {
                 return;
             if (hologram.isSpawned()) {
                 final String updatedName = Placeholders.replace(text, null, npc);
-                final Entity hologramEntity = hologram.getEntity();
-                hologramEntity.setCustomName(null);
-                // Use underlying Bukkit API to suppress rename event
-                hologramEntity.setCustomName(updatedName);
+                boolean needUpdate = !hologram.getName().equals(updatedName);
+                hologram.setName(updatedName);
+                if (needUpdate) {
+                    hologram.updateCustomName();
+                }
             }
             if (!Placeholders.containsPlaceholders(text)) {
                 hologram.data().set(NPC.Metadata.NAMEPLATE_VISIBLE, Messaging.stripColor(text).length() > 0);

--- a/main/src/main/java/net/citizensnpcs/trait/HologramTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/HologramTrait.java
@@ -868,8 +868,8 @@ public class HologramTrait extends Trait {
                 return;
             if (hologram.isSpawned()) {
                 final String updatedName = Placeholders.replace(text, null, npc);
-                boolean needUpdate = !hologram.getName().equals(updatedName);
                 hologram.setName(updatedName);
+                boolean needUpdate = !hologram.getName().equals(updatedName);
                 if (needUpdate) {
                     hologram.updateCustomName();
                 }


### PR DESCRIPTION
fixed the issue about names which are minimessages will no longer work as hologram text, this bug was introduced by #3195
but finally fixed by this PR.
and also bring back the npc rename events as NPC.setName is really necessary to ensure name reliability.
require CitizensDev/CitizensAPI#86 to be merged first.