### PR TITLE
fix: issues when using attribute key as argument

### DIFF
--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -30,6 +30,7 @@ import org.bukkit.Registry;
 import org.bukkit.Rotation;
 import org.bukkit.Sound;
 import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.command.CommandSender;
@@ -425,10 +426,10 @@ public class NPCCommands {
 
         AttributeTrait trait = npc.getOrAddTrait(AttributeTrait.class);
         if (value == null) {
-            trait.setDefaultAttribute(Registry.ATTRIBUTE.get(SpigotUtil.getKey(attribute)));
+            trait.setDefaultAttribute(Util.getAttribute(attribute));
             Messaging.sendTr(sender, Messages.ATTRIBUTE_RESET, attribute);
         } else {
-            trait.setAttributeValue(Registry.ATTRIBUTE.get(SpigotUtil.getKey(attribute)), value);
+            trait.setAttributeValue(Util.getAttribute(attribute), value);
             Messaging.sendTr(sender, Messages.ATTRIBUTE_SET, attribute, value);
         }
     }
@@ -3755,10 +3756,10 @@ public class NPCCommands {
                 trait.isTamed(), trait.getCollarColor().name());
     }
 
-    public static class OptionalAttributeCompletions extends OptionalEnumCompletions {
+    public static class OptionalAttributeCompletions implements Arg.CompletionsProvider {
         @Override
-        public String getEnumClassName() {
-            return "org.bukkit.attribute.Attribute";
+        public Collection<String> getCompletions(CommandContext args, CommandSender sender, NPC npc) {
+            return Arrays.stream(Attribute.values()).map(attr -> attr.getKey().toString()).collect(Collectors.toList());
         }
     }
 

--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -24,6 +24,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.World;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Entity;
@@ -264,6 +265,20 @@ public class Util {
             }
         }
         return null;
+    }
+
+    public static Attribute getAttribute(String... keyCandidates) {
+        for (String keyCandidate : keyCandidates) {
+            boolean isFullUpperCase = keyCandidate.toUpperCase(Locale.ENGLISH).equals(keyCandidate);
+            if (isFullUpperCase) { // we assume it is an enum key
+                try {
+                    // Just imagine we're still on older API (1.21.3-, exclusive)
+                    // noinspection deprecation
+                    return Attribute.valueOf(keyCandidate);
+                } catch (IllegalArgumentException ignored) {} // huh, not?
+            }
+        }
+        return getRegistryValue(Registry.ATTRIBUTE, keyCandidates);
     }
 
     public static String getTeamName(UUID id) {


### PR DESCRIPTION
Changes:
Added argument parsing backward compatibility for /npc attribute command but also introduces more time cost (although it might be not so long, so we can assume it as zero)
Make OptionalAttributeCompletions return attribute keys for now as old enum names are too legacy.