### PR TITLE
[Performance] v1_21_R3: Reduce number of EntityHumanNPC#getBukkitEntity calls

### DIFF
--- a/v1_21_R3/src/main/java/net/citizensnpcs/nms/v1_21_R3/entity/EntityHumanNPC.java
+++ b/v1_21_R3/src/main/java/net/citizensnpcs/nms/v1_21_R3/entity/EntityHumanNPC.java
@@ -128,10 +128,11 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
         }
         super.baseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().hasWanted();
-        if (!navigating && getBukkitEntity() != null
+        CraftPlayer craftPlayer = getBukkitEntity();
+        if (!navigating && craftPlayer != null
                 && (!npc.hasTrait(Gravity.class) || npc.getOrAddTrait(Gravity.class).hasGravity())
-                && Util.isLoaded(getBukkitEntity().getLocation())
-                && (!npc.isProtected() || SpigotUtil.checkYSafe(getY(), getBukkitEntity().getWorld()))) {
+                && Util.isLoaded(craftPlayer.getLocation())
+                && (!npc.isProtected() || SpigotUtil.checkYSafe(getY(), craftPlayer.getWorld()))) {
             moveWithFallDamage(Vec3.ZERO);
         }
         Vec3 mot = getDeltaMovement();


### PR DESCRIPTION
[Performance] v1_21_R3: Reduce number of EntityHumanNPC#getBukkitEntity calls (this could be further improved by passing CraftPlayer as param to EntityHumanNPC#moveOnCurrentHeading and backported to old versions)

![getBukkitEntity](https://github.com/user-attachments/assets/7d6e0185-aa72-4721-a00c-2c4c305e50d3)
