### PR TITLE
Include API in sources artifact

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -149,13 +149,57 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>include-api-sources</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/api-sources</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-api-sources</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>net.citizensnpcs</groupId>
+                                    <artifactId>citizensapi</artifactId>
+                                    <version>${project.version}</version>
+                                    <classifier>sources</classifier>
+                                    <outputDirectory>${project.build.directory}/api-sources</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
-                        <phase>package</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>


### PR DESCRIPTION
Improves on #3212 by attaching `citizensapi` sources directly to the sources artifact of `citizens-main`. There's two reasons for doing it this way:
1. `citizensapi` is a dependency of `citizens-main`, sources for dependencies aren't included in the sources plugin and it can't be configured to include them.
3. Even though the API is a dependency of main and it is included as a transitive dependency if not excluded, `citizens-main` already includes the compiled sources which takes precedence in your IDE and won't attach the sources from `citizensapi`. You can attach the sources manually, but this gets cleared on every maven sync if using `-SNAPSHOT` which becomes pretty burdensome.

Source generation was additionally moved to the `install` task so that included api sources wouldn't conflict with compilation.