### PR TITLE
fix: rotation changes not causing player NPC move events

### DIFF
--- a/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/EntityHumanNPC.java
+++ b/v1_10_R1/src/main/java/net/citizensnpcs/nms/v1_10_R1/entity/EntityHumanNPC.java
@@ -269,6 +269,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.k_();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         super.U();
         boolean navigating = npc.getNavigator().isNavigating() || controllerMove.a();
         if (!navigating && getBukkitEntity() != null
@@ -288,7 +289,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         cs();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.a(this);
         }

--- a/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/EntityHumanNPC.java
+++ b/v1_11_R1/src/main/java/net/citizensnpcs/nms/v1_11_R1/entity/EntityHumanNPC.java
@@ -333,6 +333,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.playerTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         cA();
         boolean navigating = npc.getNavigator().isNavigating();
         if (!navigating && getBukkitEntity() != null
@@ -352,7 +353,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         ct();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.a(this);
         }

--- a/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/EntityHumanNPC.java
+++ b/v1_12_R1/src/main/java/net/citizensnpcs/nms/v1_12_R1/entity/EntityHumanNPC.java
@@ -348,6 +348,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.playerTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         Y();
         boolean navigating = npc.getNavigator().isNavigating();
         if (!navigating && getBukkitEntity() != null
@@ -367,7 +368,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         cB();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.a(this);
         }

--- a/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/EntityHumanNPC.java
+++ b/v1_13_R2/src/main/java/net/citizensnpcs/nms/v1_13_R2/entity/EntityHumanNPC.java
@@ -330,6 +330,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.playerTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         W();
         boolean navigating = npc.getNavigator().isNavigating() || controllerMove.b();
         if (!navigating && getBukkitEntity() != null
@@ -349,7 +350,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         cN();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.a(this);
         }

--- a/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/EntityHumanNPC.java
+++ b/v1_14_R1/src/main/java/net/citizensnpcs/nms/v1_14_R1/entity/EntityHumanNPC.java
@@ -340,6 +340,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.playerTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         entityBaseTick();
         boolean navigating = npc.getNavigator().isNavigating() || controllerMove.b();
         if (!navigating && getBukkitEntity() != null
@@ -360,7 +361,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         collideNearby();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.a(this);
         }

--- a/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EntityHumanNPC.java
+++ b/v1_15_R1/src/main/java/net/citizensnpcs/nms/v1_15_R1/entity/EntityHumanNPC.java
@@ -339,6 +339,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.playerTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         entityBaseTick();
         boolean navigating = npc.getNavigator().isNavigating() || controllerMove.b();
         if (!navigating && getBukkitEntity() != null
@@ -359,7 +360,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         collideNearby();
-        NMSImpl.callNPCMoveEvent(this);
     }
 
     public void setMoveDestination(double x, double y, double z, double speed) {

--- a/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/EntityHumanNPC.java
+++ b/v1_16_R3/src/main/java/net/citizensnpcs/nms/v1_16_R3/entity/EntityHumanNPC.java
@@ -312,6 +312,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.playerTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         entityBaseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().b();
         if (!navigating && getBukkitEntity() != null
@@ -333,7 +334,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         ai.getMoveControl().a();
         ai.getJumpControl().b();
         collideNearby();
-        NMSImpl.callNPCMoveEvent(this);
     }
 
     @Override

--- a/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/entity/EntityHumanNPC.java
+++ b/v1_17_R1/src/main/java/net/citizensnpcs/nms/v1_17_R1/entity/EntityHumanNPC.java
@@ -119,6 +119,7 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             super.doTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         super.baseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().hasWanted();
         if (!navigating && getBukkitEntity() != null
@@ -144,7 +145,6 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             this.onGround = false;
         }
         pushEntities();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.tick(this);
         }

--- a/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/entity/EntityHumanNPC.java
+++ b/v1_18_R2/src/main/java/net/citizensnpcs/nms/v1_18_R2/entity/EntityHumanNPC.java
@@ -120,6 +120,7 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             super.doTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         super.baseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().hasWanted();
         if (!navigating && getBukkitEntity() != null
@@ -145,7 +146,6 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             this.onGround = false;
         }
         pushEntities();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.tick(this);
         }

--- a/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EntityHumanNPC.java
+++ b/v1_19_R3/src/main/java/net/citizensnpcs/nms/v1_19_R3/entity/EntityHumanNPC.java
@@ -123,6 +123,7 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             super.doTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         super.baseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().hasWanted();
         if (!navigating && getBukkitEntity() != null
@@ -149,7 +150,6 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             this.onGround = false;
         }
         pushEntities();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.tick(this);
         }

--- a/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EntityHumanNPC.java
+++ b/v1_20_R4/src/main/java/net/citizensnpcs/nms/v1_20_R4/entity/EntityHumanNPC.java
@@ -125,6 +125,7 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             super.doTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         super.baseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().hasWanted();
         if (!navigating && getBukkitEntity() != null
@@ -150,7 +151,6 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             onGround = false;
         }
         pushEntities();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.tick(this);
         }

--- a/v1_21_R3/src/main/java/net/citizensnpcs/nms/v1_21_R3/entity/EntityHumanNPC.java
+++ b/v1_21_R3/src/main/java/net/citizensnpcs/nms/v1_21_R3/entity/EntityHumanNPC.java
@@ -126,6 +126,7 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             super.doTick();
             return;
         }
+        NMSImpl.callNPCMoveEvent(npc, this);
         super.baseTick();
         boolean navigating = npc.getNavigator().isNavigating() || ai.getMoveControl().hasWanted();
         if (!navigating && getBukkitEntity() != null
@@ -151,7 +152,6 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
             onGround = false;
         }
         pushEntities();
-        NMSImpl.callNPCMoveEvent(npc, this);
         if (npc.useMinecraftAI()) {
             foodData.tick(this);
         }

--- a/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/EntityHumanNPC.java
+++ b/v1_8_R3/src/main/java/net/citizensnpcs/nms/v1_8_R3/entity/EntityHumanNPC.java
@@ -271,6 +271,7 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
             super.l();
             return;
         }
+        NMSImpl.callNPCMoveEvent(this);
         super.K();
         boolean navigating = npc.getNavigator().isNavigating() || controllerMove.a();
         if (!navigating && getBukkitEntity() != null
@@ -290,7 +291,6 @@ public class EntityHumanNPC extends EntityPlayer implements NPCHolder, Skinnable
         }
         updateAI();
         bL();
-        NMSImpl.callNPCMoveEvent(this);
         if (npc.useMinecraftAI()) {
             foodData.a(this);
         }


### PR DESCRIPTION
I think it is necessary to be fixed so I made this PR.

I know this will make NPC move event being called for more times but I'll improve NPCMoveEvent by:
https://github.com/CitizensDev/CitizensAPI/pull/87

Originally I should already made this 2 months ago, how the PR works is described by the message:
https://discord.com/channels/315163488085475337/1101526181502795776/1319848988077457450