### PR TITLE
Allow to set BlockFace for Item frames

### DIFF
--- a/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
+++ b/main/src/main/java/net/citizensnpcs/commands/NPCCommands.java
@@ -1653,7 +1653,7 @@ public class NPCCommands {
 
     @Command(
             aliases = { "npc" },
-            usage = "itemframe --visible [true|false] --fixed [true|false] --rotation [rotation] --item [item]",
+            usage = "itemframe --visible [true|false] --fixed [true|false] --rotation [rotation] --item [item] --face [face]",
             desc = "",
             modifiers = { "itemframe" },
             min = 1,
@@ -1662,7 +1662,8 @@ public class NPCCommands {
             permission = "citizens.npc.itemframe")
     @Requirements(ownership = true, selected = true, types = EntityType.ITEM_FRAME)
     public void itemframe(CommandContext args, CommandSender sender, NPC npc, @Flag("visible") Boolean visible,
-            @Flag("fixed") Boolean fixed, @Flag("rotation") Rotation rotation, @Flag("item") ItemStack item)
+            @Flag("fixed") Boolean fixed, @Flag("rotation") Rotation rotation, @Flag("item") ItemStack item,
+            @Flag("face") BlockFace face)
             throws CommandException {
         ItemFrameTrait ift = npc.getOrAddTrait(ItemFrameTrait.class);
         String msg = "";
@@ -1681,6 +1682,10 @@ public class NPCCommands {
         if (rotation != null) {
             ift.setRotation(rotation);
             msg += " " + Messaging.tr(Messages.ITEMFRAME_ROTATION_SET, rotation);
+        }
+        if (face != null) {
+            ift.setFacing(face);
+            msg += " " + Messaging.tr(Messages.ITEMFRAME_BLOCKFACE_SET, face);
         }
         if (msg.isEmpty())
             throw new CommandUsageException();

--- a/main/src/main/java/net/citizensnpcs/trait/ItemFrameTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ItemFrameTrait.java
@@ -1,6 +1,7 @@
 package net.citizensnpcs.trait;
 
 import org.bukkit.Rotation;
+import org.bukkit.block.BlockFace;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.inventory.ItemStack;
 
@@ -21,6 +22,8 @@ public class ItemFrameTrait extends Trait {
     private Rotation rotation = Rotation.NONE;
     @Persist
     private boolean visible = true;
+    @Persist
+    private BlockFace facing = BlockFace.NORTH;
 
     public ItemFrameTrait() {
         super("itemframe");
@@ -38,6 +41,10 @@ public class ItemFrameTrait extends Trait {
         return rotation;
     }
 
+    public BlockFace getFacing() {
+        return facing;
+    }
+
     public boolean isVisible() {
         return visible;
     }
@@ -51,6 +58,9 @@ public class ItemFrameTrait extends Trait {
             }
             if (item != null) {
                 frame.setItem(item);
+            }
+            if (facing != null) {
+                frame.setFacingDirection(facing);
             }
             if (fixed != null) {
                 frame.setFixed(fixed);
@@ -78,6 +88,11 @@ public class ItemFrameTrait extends Trait {
 
     public void setVisible(boolean visible) {
         this.visible = visible;
+        onSpawn();
+    }
+
+    public void setFacing(BlockFace face) {
+        this.facing = face;
         onSpawn();
     }
 }

--- a/main/src/main/java/net/citizensnpcs/util/Messages.java
+++ b/main/src/main/java/net/citizensnpcs/util/Messages.java
@@ -232,6 +232,7 @@ public class Messages {
     public static final String ITEMFRAME_FIXED_SET = "citizens.commands.npc.itemframe.fixed-set";
     public static final String ITEMFRAME_ITEM_SET = "citizens.commands.npc.itemframe.item-set";
     public static final String ITEMFRAME_ROTATION_SET = "citizens.commands.npc.itemframe.rotation-set";
+    public static final String ITEMFRAME_BLOCKFACE_SET = "citizens.commands.npc.itemframe.blockface-set";
     public static final String ITEMFRAME_VISIBLE_SET = "citizens.commands.npc.itemframe.visible-set";
     public static final String KNOCKBACK_SET = "citizens.commands.npc.knockback.set";
     public static final String KNOCKBACK_UNSET = "citizens.commands.npc.knockback.unset";

--- a/main/src/main/resources/en.json
+++ b/main/src/main/resources/en.json
@@ -299,6 +299,7 @@
   "citizens.commands.npc.itemframe.fixed-set" : "Fixed (whether the item can be rotated) set to [[{0}]]",
   "citizens.commands.npc.itemframe.item-set" : "Item set to [[{0}]]",
   "citizens.commands.npc.itemframe.rotation-set" : "Rotation set to [[{0}]]",
+  "citizens.commands.npc.itemframe.blockface-set" : "BlockFace set to [[{0}]]",
   "citizens.commands.npc.itemframe.visible-set" : "Visible set to [[{0}]]",
   "citizens.commands.npc.jump.description": "Makes the NPC jump",
   "citizens.commands.npc.jump.help" : "",


### PR DESCRIPTION
Add a new property to the ItemFrameTrait to set the facing for Item Frames. Currently facing of item frames can't be changed.