### PR TITLE
Receive behavior map with a more generic type

### DIFF
--- a/v1_21_R4/src/main/java/net/citizensnpcs/nms/v1_21_R4/util/NMSImpl.java
+++ b/v1_21_R4/src/main/java/net/citizensnpcs/nms/v1_21_R4/util/NMSImpl.java
@@ -2257,9 +2257,9 @@ public class NMSImpl implements NMSBridge {
         throw new IllegalArgumentException();
     }
 
-    public static TreeMap<?, ?> getBehaviorMap(LivingEntity entity) {
+    public static Map<?, ?> getBehaviorMap(LivingEntity entity) {
         try {
-            return (TreeMap<?, ?>) AVAILABLE_BEHAVIORS_BY_PRIORITY.invoke(entity.getBrain());
+            return (Map<?, ?>) AVAILABLE_BEHAVIORS_BY_PRIORITY.invoke(entity.getBrain());
         } catch (Throwable e) {
             e.printStackTrace();
         }
@@ -2725,7 +2725,7 @@ public class NMSImpl implements NMSBridge {
             }
         } else {
             clearGoals(npc, entity.goalSelector, entity.targetSelector);
-            TreeMap behaviorMap = getBehaviorMap(entity);
+            Map behaviorMap = getBehaviorMap(entity);
             if (behaviorMap.size() > 0) {
                 npc.data().set("behavior-map", new TreeMap(behaviorMap));
                 behaviorMap.clear();


### PR DESCRIPTION
This pull request changed the NMS `V1_21_4` original type `TreeMap` to a more generic `Map`.

Will allow server software to do more optimizations like replacing map with their faster implementation while maintaining compatibility with Citizens.

Creating `TreeMap`s from other map implementations still work fine