### PR TITLE
Fix Folia start and reload

### DIFF
--- a/main/src/main/java/net/citizensnpcs/util/NMS.java
+++ b/main/src/main/java/net/citizensnpcs/util/NMS.java
@@ -94,7 +94,12 @@ public class NMS {
     }
 
     public static void addOrRemoveFromPlayerList(org.bukkit.entity.Entity entity, boolean remove) {
-        BRIDGE.addOrRemoveFromPlayerList(entity, remove);
+        // It needs to call spawnChunkTracker, which must be called on the regional thread.
+        if (CitizensAPI.getScheduler().isOnOwnerThread(entity.getLocation())) {
+            BRIDGE.addOrRemoveFromPlayerList(entity, remove);
+        } else {
+            CitizensAPI.getScheduler().runRegionTask(entity.getLocation(), () -> BRIDGE.addOrRemoveFromPlayerList(entity, remove));
+        }
     }
 
     public static void attack(LivingEntity attacker, LivingEntity bukkitTarget) {
@@ -851,10 +856,11 @@ public class NMS {
     }
 
     public static void removeFromWorld(org.bukkit.entity.Entity entity) {
-        if (CitizensAPI.getScheduler().isOnOwnerThread(entity)) {
+        // It needs to call spawnChunkTracker, which must be called on the regional thread.
+        if (CitizensAPI.getScheduler().isOnOwnerThread(entity.getLocation())) {
             BRIDGE.removeFromWorld(entity);
         } else {
-            CitizensAPI.getScheduler().runEntityTask(entity, () -> BRIDGE.removeFromWorld(entity));
+            CitizensAPI.getScheduler().runRegionTask(entity.getLocation(), () -> BRIDGE.removeFromWorld(entity));
         }
     }
 

--- a/v1_21_R5/src/main/java/net/citizensnpcs/nms/v1_21_R5/entity/HumanController.java
+++ b/v1_21_R5/src/main/java/net/citizensnpcs/nms/v1_21_R5/entity/HumanController.java
@@ -58,8 +58,6 @@ public class HumanController extends AbstractEntityController {
                     || getBukkitEntity() != handle.getBukkitEntity())
                 return;
             NMS.addOrRemoveFromPlayerList(getBukkitEntity(), npc.shouldRemoveFromPlayerList());
-            CitizensAPI.getScheduler().runEntityTask(getBukkitEntity(),
-                    () -> NMS.addOrRemoveFromPlayerList(getBukkitEntity(), npc.shouldRemoveFromPlayerList()));
         }, 20);
         handle.getBukkitEntity().setSleepingIgnored(true);
         return handle.getBukkitEntity();

--- a/v1_21_R6/src/main/java/net/citizensnpcs/nms/v1_21_R6/entity/HumanController.java
+++ b/v1_21_R6/src/main/java/net/citizensnpcs/nms/v1_21_R6/entity/HumanController.java
@@ -58,8 +58,6 @@ public class HumanController extends AbstractEntityController {
                     || getBukkitEntity() != handle.getBukkitEntity())
                 return;
             NMS.addOrRemoveFromPlayerList(getBukkitEntity(), npc.shouldRemoveFromPlayerList());
-            CitizensAPI.getScheduler().runEntityTask(getBukkitEntity(),
-                    () -> NMS.addOrRemoveFromPlayerList(getBukkitEntity(), npc.shouldRemoveFromPlayerList()));
         }, 20);
         handle.getBukkitEntity().setSleepingIgnored(true);
         return handle.getBukkitEntity();

--- a/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/entity/HumanController.java
+++ b/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/entity/HumanController.java
@@ -58,8 +58,6 @@ public class HumanController extends AbstractEntityController {
                     || getBukkitEntity() != handle.getBukkitEntity())
                 return;
             NMS.addOrRemoveFromPlayerList(getBukkitEntity(), npc.shouldRemoveFromPlayerList());
-            CitizensAPI.getScheduler().runEntityTask(getBukkitEntity(),
-                    () -> NMS.addOrRemoveFromPlayerList(getBukkitEntity(), npc.shouldRemoveFromPlayerList()));
         }, 20);
         handle.getBukkitEntity().setSleepingIgnored(true);
         return handle.getBukkitEntity();


### PR DESCRIPTION
- NMS#addOrRemoveFromPlayerList must be called on the regional thread and not the entity thread  = https://pastebin.com/raw/u16VD01c
- NMS#removeFromWorld must be called on the regional thread and not on the entity thread because entities are added or deleted on the regional thread  = https://pastebin.com/raw/e00exdkY

- Removing a duplicate NMS#addOrRemoveFromPlayerList
