### PR TITLE
Adjust the behavior of EntityHumanNPC's invulnerability to reflect only the currently set no-damage ticks

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
+++ b/main/src/main/java/net/citizensnpcs/npc/CitizensNPC.java
@@ -427,9 +427,6 @@ public class CitizensNPC extends AbstractNPC {
                         }
                         le.setNoDamageTicks(data().get(NPC.Metadata.SPAWN_NODAMAGE_TICKS,
                                 Setting.DEFAULT_SPAWN_NODAMAGE_DURATION.asTicks()));
-                        if (le.getNoDamageTicks() == 0) {
-                            le.setInvulnerable(false);
-                        }
                     }
                     if (requiresNameHologram() && !hasTrait(HologramTrait.class)) {
                         addTrait(HologramTrait.class);

--- a/v1_21_R6/src/main/java/net/citizensnpcs/nms/v1_21_R6/entity/EntityHumanNPC.java
+++ b/v1_21_R6/src/main/java/net/citizensnpcs/nms/v1_21_R6/entity/EntityHumanNPC.java
@@ -289,6 +289,16 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
     }
 
     @Override
+    public boolean isInvulnerable() {
+        return getBukkitEntity().getNoDamageTicks() > 0;
+    }
+
+    @Override
+    public boolean isInvulnerableTo(ServerLevel level, DamageSource source) {
+        return isInvulnerable();
+    }
+
+    @Override
     public boolean isInWall() {
         if (npc == null || noPhysics || isSleeping())
             return super.isInWall();

--- a/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/entity/EntityHumanNPC.java
+++ b/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/entity/EntityHumanNPC.java
@@ -290,6 +290,16 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
     }
 
     @Override
+    public boolean isInvulnerable() {
+        return getBukkitEntity().getNoDamageTicks() > 0;
+    }
+
+    @Override
+    public boolean isInvulnerableTo(ServerLevel level, DamageSource source) {
+        return isInvulnerable();
+    }
+
+    @Override
     public boolean isInWall() {
         if (npc == null || noPhysics || isSleeping())
             return super.isInWall();

--- a/v26_1_R1/src/main/java/net/citizensnpcs/nms/v26_1_R1/entity/EntityHumanNPC.java
+++ b/v26_1_R1/src/main/java/net/citizensnpcs/nms/v26_1_R1/entity/EntityHumanNPC.java
@@ -288,6 +288,16 @@ public class EntityHumanNPC extends ServerPlayer implements NPCHolder, Skinnable
     }
 
     @Override
+    public boolean isInvulnerable() {
+        return getBukkitEntity().getNoDamageTicks() > 0;
+    }
+
+    @Override
+    public boolean isInvulnerableTo(ServerLevel level, DamageSource source) {
+        return isInvulnerable();
+    }
+
+    @Override
     public boolean isInWall() {
         if (npc == null || noPhysics || isSleeping())
             return super.isInWall();


### PR DESCRIPTION
When teleporting to Player-NPCs in unloaded chunks, the NPC remains in invulnerability-mode for first few seconds (typically three, round about), which causes left-click to be unavailable - all despite configuring a no-damage-ticks value of zero.

This concise patch overrides invulnerability to be defined as having a value of said no-damage-ticks greater than zero, which preserves existing features and doesn't break anything that I am aware of and have tested.