### PR TITLE
fix: toggle `SUPPORTS_HAS_EQUIPPABLE` flag to true when reflection succeeds

### DIFF
--- a/main/src/main/java/net/citizensnpcs/util/Util.java
+++ b/main/src/main/java/net/citizensnpcs/util/Util.java
@@ -459,6 +459,7 @@ public class Util {
         TWO_DIGIT_DECIMAL.setMaximumFractionDigits(2);
         try {
             ItemMeta.class.getMethod("hasEquippable");
+            SUPPORTS_HAS_EQUIPPABLE = true;
         } catch (NoSuchMethodException e) {
             SUPPORTS_HAS_EQUIPPABLE = false;
         }


### PR DESCRIPTION
The static block checking for `hasEquippable` support was catching `NoSuchMethodException` and setting the flag to `false`. if the method did exist (on newer versions), it forgot to actually set the flag to `true`. because it defaults to false at initialization, NPC equipment features were breaking in `1.21`+.

This pull request simply adds `SUPPORTS_HAS_EQUIPPABLE = true;` inside the `try` block.