### PR TITLE
perf: limit A* iterations and fix async pathfinding leaks

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/ai/AStarNavigationStrategy.java
+++ b/main/src/main/java/net/citizensnpcs/npc/ai/AStarNavigationStrategy.java
@@ -66,8 +66,9 @@ public class AStarNavigationStrategy extends AbstractPathStrategy {
         destination = dest;
         // TODO: simplify
         if (params.pathfinderType() == PathfinderType.CITIZENS_ASYNC) {
-            planner = new AsyncAStarPlanner(CitizensAPI.getAsyncChunkCache()
-                    .findPathAsync(new PathRequest(npc.getEntity().getLocation(), dest, 1, params)));
+            planner = new AsyncAStarPlanner(CitizensAPI.getAsyncChunkCache().findPathAsync(new PathRequest(
+                    npc.getEntity().getLocation(), dest, 1, params,
+                    Setting.CITIZENS_PATHFINDER_MAXIMUM_ASTAR_ITERATIONS.asInt())));
         } else {
             planner = new AStarPlanner(params, npc.getEntity().getLocation(), destination);
         }
@@ -92,6 +93,12 @@ public class AStarNavigationStrategy extends AbstractPathStrategy {
     public void stop() {
         if (plan != null && params.debug()) {
             Util.sendBlockChanges(plan.getBlocks(npc.getEntity().getWorld()), null);
+        }
+        // Cancel any in-flight async request; it was previously abandoned on stop(), so every dynamic-target
+        // repath left a live request occupying the worker pool + its captured chunk snapshots.
+        if (planner != null) {
+            planner.cancel();
+            planner = null;
         }
         plan = null;
     }
@@ -224,6 +231,11 @@ public class AStarNavigationStrategy extends AbstractPathStrategy {
         }
 
         @Override
+        public void cancel() {
+            future.cancel(true);
+        }
+
+        @Override
         public Path getPath() {
             return path;
         }
@@ -249,6 +261,9 @@ public class AStarNavigationStrategy extends AbstractPathStrategy {
 
     // TODO: lift this into a navigationstrategy rather than this arbitrary interface
     public static interface PathPlanner {
+        default void cancel() {
+        }
+
         public Path getPath();
 
         public CancelReason tick();


### PR DESCRIPTION
### Summary
Complements the previous chunk cache fixes by passing max iteration limits and properly cancelling in-flight async pathfinding requests.

### Changes
* **Pass Max Iterations:** Updated the async `PathRequest` to pass `Setting.CITIZENS_PATHFINDER_MAXIMUM_ASTAR_ITERATIONS`, capping the iteration count instead of leaving it unbounded.
* **Cancel In-Flight Requests on Stop:** Previously, when pathfinding stopped or re-pathed, async requests were simply abandoned. This left active requests taking up worker pool slots and holding onto chunk snapshots. Added a explicit `planner.cancel()` call to kill ongoing async tasks immediately.
* **Added Cancel Support:** Implemented the `cancel()` method in the `PathPlanner` interface and `AsyncAStarPlanner` to properly cancel the underlying `CompletableFuture`.