### PR TITLE
Fix BungeeCord disconnect on NPC update by using correct scoreboard team packet mode

### DIFF
--- a/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
+++ b/main/src/main/java/net/citizensnpcs/trait/ScoreboardTrait.java
@@ -226,7 +226,7 @@ public class ScoreboardTrait extends Trait {
                 continue;
 
             if (metadata.has(player.getUniqueId(), team.getName())) {
-                team.sendToPlayer(player, AbstractTeam.SendMode.ADD_OR_MODIFY);
+                team.sendToPlayer(player, AbstractTeam.SendMode.UPDATE);
             } else {
                 team.sendToPlayer(player, AbstractTeam.SendMode.ADD_OR_MODIFY);
 

--- a/main/src/main/java/net/citizensnpcs/trait/scoreboard/AbstractTeam.java
+++ b/main/src/main/java/net/citizensnpcs/trait/scoreboard/AbstractTeam.java
@@ -255,7 +255,8 @@ public interface AbstractTeam {
      */
     enum SendMode {
         ADD_OR_MODIFY(0),
-        REMOVE(1);
+        REMOVE(1),
+        UPDATE(2);
 
         private final int value;
 


### PR DESCRIPTION
### Summary
when creating or updating an NPC (eg, renaming, changing skins) on a server behind a BungeeCord proxy, all players in the area are disconnected from the proxy; BungeeCord throws the following exception on the network thread:
```java.lang.IllegalArgumentException: Team CIT-<uuid> already exists in this scoreboard @ com.google.common.base.Preconditions:217```

### The Cause
A recent change to the `AbstractTeam` abstraction (specifically around Folia scoreboard support) merged team creation and updates into a single `SendMode.ADD_OR_MODIFY` mapping to packet mode `0`/`Create`. 

When an NPC updates, Citizens sends a mode `0`/`Create` packet to players who already have the team registered via `metadata.has(...)`; Paper and vanilla clients handle this fine but BungeeCord uses a more strict internal scoreboard state map per player. when BungeeCord receives a `Create Team` packet for a team it already tracks, it throws the `IllegalArgumentException` and drops the downstream connection

### The Fix
- added `UPDATE(2)` to the `SendMode` enum in `AbstractTeam.java`.
- updated `ScoreboardTrait.java` to send `AbstractTeam.SendMode.UPDATE` instead of `ADD_OR_MODIFY` if the player already has the team registered in their metadata.

### Testing
Tested locally on Paper `1.21.11` and `Paper 26.1.2` behind BungeeCord. was able to replicate the issue running:
- `/npc create CollisionTest`
- `/npc rename CollisionTest2`
- `/npc skin notch`
after the patch, running `/npc rename` and `/npc skin` correctly sends the update packet, and BungeeCord doesn't kick the player connection(s)