### PR TITLE
Fix Folia skin tracker concurrent access

### DIFF
--- a/main/src/main/java/net/citizensnpcs/npc/skin/SkinUpdateTracker.java
+++ b/main/src/main/java/net/citizensnpcs/npc/skin/SkinUpdateTracker.java
@@ -1,10 +1,8 @@
 package net.citizensnpcs.npc.skin;
 
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -12,6 +10,8 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import javax.annotation.Nullable;
 
@@ -37,8 +37,8 @@ import net.citizensnpcs.util.Util;
  * @see net.citizensnpcs.EventListen
  */
 public class SkinUpdateTracker {
-    private final Map<SkinnableEntity, Void> navigating = new WeakHashMap<>(25);
-    private final Map<UUID, PlayerTracker> playerTrackers = new HashMap<>(
+    private final Map<SkinnableEntity, Void> navigating = Collections.synchronizedMap(new WeakHashMap<>(25));
+    private final Map<UUID, PlayerTracker> playerTrackers = new ConcurrentHashMap<>(
             Math.max(128, Math.min(1024, Bukkit.getMaxPlayers() / 2)));
     private final NPCNavigationUpdater updater = new NPCNavigationUpdater();
 
@@ -111,7 +111,11 @@ public class SkinUpdateTracker {
     private void getNewVisibleNavigating(Player player, Collection<SkinnableEntity> output) {
         PlayerTracker tracker = getTracker(player, false);
 
-        for (SkinnableEntity skinnable : navigating.keySet()) {
+        List<SkinnableEntity> snapshot;
+        synchronized (navigating) {
+            snapshot = new ArrayList<>(navigating.keySet());
+        }
+        for (SkinnableEntity skinnable : snapshot) {
             // make sure player hasn't already been updated to prevent excessive tab list flashing
             // while NPC's are navigating and to reduce the number of times #canSee is invoked.
             if (tracker.fovVisibleSkins.contains(skinnable))
@@ -133,11 +137,8 @@ public class SkinUpdateTracker {
 
     // get a players tracker, create new one if not exists.
     private PlayerTracker getTracker(Player player, boolean reset) {
-        PlayerTracker tracker = playerTrackers.get(player.getUniqueId());
-        if (tracker == null) {
-            tracker = new PlayerTracker(player);
-            playerTrackers.put(player.getUniqueId(), tracker);
-        } else if (reset) {
+        PlayerTracker tracker = playerTrackers.computeIfAbsent(player.getUniqueId(), ignored -> new PlayerTracker(player));
+        if (reset) {
             tracker.hardReset(player);
         }
         return tracker;
@@ -333,12 +334,12 @@ public class SkinUpdateTracker {
     // Updates players. Repeating task used to schedule updates without
     // causing excessive scheduling.
     private static class NPCNavigationUpdater extends SchedulerRunnable {
-        Queue<UpdateInfo> queue = new ArrayDeque<>(20);
+        final Queue<UpdateInfo> queue = new ConcurrentLinkedQueue<>();
 
         @Override
         public void run() {
-            while (!queue.isEmpty()) {
-                UpdateInfo info = queue.remove();
+            UpdateInfo info;
+            while ((info = queue.poll()) != null) {
                 info.entity.getSkinTracker().updateViewer(info.player);
             }
         }
@@ -347,7 +348,7 @@ public class SkinUpdateTracker {
     // Tracks player location and yaw to determine when the player should be updated
     // with nearby skins.
     private static class PlayerTracker {
-        Set<SkinnableEntity> fovVisibleSkins = new HashSet<>(10);
+        final Set<SkinnableEntity> fovVisibleSkins = ConcurrentHashMap.newKeySet();
         boolean hasMoved;
         Location location = new Location(null, 0, 0, 0);
         float lowerBound;
@@ -360,7 +361,7 @@ public class SkinUpdateTracker {
         }
 
         // reset all
-        void hardReset(Player player) {
+        synchronized void hardReset(Player player) {
             hasMoved = false;
             rotationCount = 0;
             lowerBound = upperBound = startYaw = 0;
@@ -369,7 +370,7 @@ public class SkinUpdateTracker {
         }
 
         // resets initial yaw and location to the players current location and yaw.
-        void reset(Player player) {
+        synchronized void reset(Player player) {
             player.getLocation(location);
             if (rotationCount < 3) {
                 float rotationDegrees = Setting.NPC_SKIN_ROTATION_UPDATE_DEGREES.asFloat();
@@ -383,7 +384,7 @@ public class SkinUpdateTracker {
             }
         }
 
-        boolean shouldUpdate(Player player) {
+        synchronized boolean shouldUpdate(Player player) {
             if (SUPPORTS_WORLD_LOADED && !location.isWorldLoaded()) {
                 hardReset(player);
                 return true;
@@ -425,8 +426,8 @@ public class SkinUpdateTracker {
     }
 
     private static class UpdateInfo {
-        SkinnableEntity entity;
-        Player player;
+        final SkinnableEntity entity;
+        final Player player;
 
         UpdateInfo(Player player, SkinnableEntity entity) {
             this.player = player;


### PR DESCRIPTION
## Summary

- Snapshot the synchronized weak navigation map before iterating it.
- Use concurrent collections for player trackers, pending skin updates, and
  visible-skin state.
- Serialize `PlayerTracker` reset/update state transitions.
- Use `computeIfAbsent` when creating per-player trackers.

## Problem

On Folia, `NPCNavigationTracker` runs from the global region scheduler while
navigation events and skin visibility updates may execute on different region
or entity schedulers. `navigationMap` was a plain `WeakHashMap`, so mutation
during `getNewVisibleNavigating()` iteration could throw:

```text
java.util.ConcurrentModificationException
    at java.util.WeakHashMap$HashIterator.nextEntry(WeakHashMap.java:816)
    at net.citizensnpcs.npc.skin.SkinUpdateTracker.getNewVisibleNavigating(SkinUpdateTracker.java:114)
    at net.citizensnpcs.npc.skin.SkinUpdateTracker$NPCNavigationTracker.run(SkinUpdateTracker.java:320)
    at io.papermc.paper.threadedregions.scheduler.FoliaGlobalRegionScheduler.tick(...)
```

The other mutable tracker collections could be accessed by the same scheduler
combination, so this patch applies the same thread-safety boundary to them.

## Testing

- Rebased onto current Citizens `master`.
- Full Maven `compile` reactor passes for `v1_21_R7`, `v26_1_R1`, and
  `v26_2_R1`.
- The equivalent fix was exercised with a Citizens b4220-derived build on
  Folia 26.1.2 and Canvas 26.1.2 under a 100-player-NPC combat/navigation load.
  The `WeakHashMap` concurrent modification error did not recur.