### PR TITLE
Fix Folia entity tracker replacement and viewer scheduling

### DIFF
--- a/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/util/CitizensEntityTracker.java
+++ b/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/util/CitizensEntityTracker.java
@@ -3,6 +3,8 @@ package net.citizensnpcs.nms.v1_21_R7.util;
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -14,6 +16,7 @@ import net.citizensnpcs.api.event.NPCLinkToPlayerEvent;
 import net.citizensnpcs.api.event.NPCSeenByPlayerEvent;
 import net.citizensnpcs.api.event.NPCUnlinkFromPlayerEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.util.SpigotUtil;
 import net.citizensnpcs.nms.v1_21_R7.entity.EntityHumanNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.NMS;
@@ -25,13 +28,15 @@ import net.minecraft.server.network.ServerPlayerConnection;
 import net.minecraft.world.entity.Entity;
 
 public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
+    private final Set<UUID> foliaPendingUpdates = ConcurrentHashMap.newKeySet();
+    private final Set<ServerPlayerConnection> rawSeenBy;
     private final Entity tracker;
 
     public CitizensEntityTracker(ChunkMap map, Entity entity, int i, int j, boolean flag) {
         map.super(entity, i, j, flag);
+        this.rawSeenBy = seenBy;
         this.tracker = entity;
         try {
-            Set<ServerPlayerConnection> set = seenBy;
             TRACKING_SET_SETTER.invoke(this, new ForwardingSet<ServerPlayerConnection>() {
                 @Override
                 public boolean add(ServerPlayerConnection conn) {
@@ -45,7 +50,7 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
 
                 @Override
                 protected Set<ServerPlayerConnection> delegate() {
-                    return set;
+                    return rawSeenBy;
                 }
 
                 @Override
@@ -70,29 +75,63 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
     private void cancellableUpdatePlayer(final NPC npc, final ServerPlayer entityplayer,
             final java.util.function.Consumer<Boolean> callback) {
         CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(), () -> {
-            NPCSeenByPlayerEvent event = new NPCSeenByPlayerEvent(npc, entityplayer.getBukkitEntity());
-            try {
-                Bukkit.getPluginManager().callEvent(event);
-            } catch (IllegalStateException e) {
-                REQUIRES_SYNC = true;
-                throw e;
-            }
-            if (event.isCancelled()) {
-                callback.accept(true);
-                return;
-            }
-            Integer trackingRange = npc.data().get(NPC.Metadata.TRACKING_RANGE);
-            if (TRACKING_RANGE_SETTER != null && trackingRange != null
-                    && npc.data().get("last-tracking-range", -1) != trackingRange.intValue()) {
-                try {
-                    TRACKING_RANGE_SETTER.invoke(CitizensEntityTracker.this, trackingRange);
-                    npc.data().set("last-tracking-range", trackingRange);
-                } catch (Throwable e) {
-                    e.printStackTrace();
-                }
-            }
-            callback.accept(false);
+            callback.accept(isUpdateCancelled(npc, entityplayer));
         });
+    }
+
+    private boolean isUpdateCancelled(final NPC npc, final ServerPlayer entityplayer) {
+        NPCSeenByPlayerEvent event = new NPCSeenByPlayerEvent(npc, entityplayer.getBukkitEntity());
+        try {
+            Bukkit.getPluginManager().callEvent(event);
+        } catch (IllegalStateException e) {
+            REQUIRES_SYNC = true;
+            throw e;
+        }
+        if (event.isCancelled()) {
+            return true;
+        }
+        Integer trackingRange = npc.data().get(NPC.Metadata.TRACKING_RANGE);
+        if (TRACKING_RANGE_SETTER != null && trackingRange != null
+                && npc.data().get("last-tracking-range", -1) != trackingRange.intValue()) {
+            try {
+                TRACKING_RANGE_SETTER.invoke(CitizensEntityTracker.this, trackingRange);
+                npc.data().set("last-tracking-range", trackingRange);
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+        }
+        return false;
+    }
+
+    private void updatePlayerFolia(final ServerPlayer entityplayer) {
+        UUID playerId = entityplayer.getUUID();
+        if (!foliaPendingUpdates.add(playerId)) {
+            return;
+        }
+        CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(), () -> {
+            try {
+                if (tracker.isRemoved()) {
+                    return;
+                }
+                if (!seenBy.contains(entityplayer.connection) && tracker instanceof NPCHolder
+                        && isUpdateCancelled(((NPCHolder) tracker).getNPC(), entityplayer)) {
+                    return;
+                }
+                super.updatePlayer(entityplayer);
+            } finally {
+                foliaPendingUpdates.remove(playerId);
+            }
+        });
+    }
+
+    @Override
+    public void removePlayer(final ServerPlayer entityplayer) {
+        if (!SpigotUtil.isFoliaServer()) {
+            super.removePlayer(entityplayer);
+            return;
+        }
+        CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(),
+                () -> CitizensEntityTracker.super.removePlayer(entityplayer));
     }
 
     @Override
@@ -100,6 +139,10 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
         if (entityplayer instanceof EntityHumanNPC)
             return;
 
+        if (SpigotUtil.isFoliaServer()) {
+            updatePlayerFolia(entityplayer);
+            return;
+        }
         if (!tracker.isRemoved() && !seenBy.contains(entityplayer.connection) && tracker instanceof NPCHolder) {
             NPC npc = ((NPCHolder) tracker).getNPC();
             if (REQUIRES_SYNC == null) {
@@ -118,6 +161,10 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
 
     public static Collection<org.bukkit.entity.Entity> getSeenBy(TrackedEntity tracker) {
         return tracker.seenBy.stream().map(c -> c.getPlayer().getBukkitEntity()).collect(Collectors.toSet());
+    }
+
+    static void transferSeenBy(TrackedEntity previous, CitizensEntityTracker replacement) {
+        replacement.rawSeenBy.addAll(previous.seenBy);
     }
 
     private static boolean getTrackDelta(TrackedEntity entry) {

--- a/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/util/NMSImpl.java
+++ b/v1_21_R7/src/main/java/net/citizensnpcs/nms/v1_21_R7/util/NMSImpl.java
@@ -1434,8 +1434,8 @@ public class NMSImpl implements NMSBridge {
                 entry = getTrackedEntityFolia(handle);
                 if (entry == null)
                     return;
-                entry.broadcastRemoved();
                 CitizensEntityTracker newTracker = new CitizensEntityTracker(server.getChunkSource().chunkMap, entry);
+                CitizensEntityTracker.transferSeenBy(entry, newTracker);
                 try {
                     ENTITY_TRACKER_SETTER_FOLIA.invoke(handle, newTracker);
                 } catch (Throwable t) {

--- a/v26_1_R1/src/main/java/net/citizensnpcs/nms/v26_1_R1/util/CitizensEntityTracker.java
+++ b/v26_1_R1/src/main/java/net/citizensnpcs/nms/v26_1_R1/util/CitizensEntityTracker.java
@@ -3,6 +3,8 @@ package net.citizensnpcs.nms.v26_1_R1.util;
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -14,6 +16,7 @@ import net.citizensnpcs.api.event.NPCLinkToPlayerEvent;
 import net.citizensnpcs.api.event.NPCSeenByPlayerEvent;
 import net.citizensnpcs.api.event.NPCUnlinkFromPlayerEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.util.SpigotUtil;
 import net.citizensnpcs.nms.v26_1_R1.entity.EntityHumanNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.NMS;
@@ -25,13 +28,15 @@ import net.minecraft.server.network.ServerPlayerConnection;
 import net.minecraft.world.entity.Entity;
 
 public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
+    private final Set<UUID> foliaPendingUpdates = ConcurrentHashMap.newKeySet();
+    private final Set<ServerPlayerConnection> rawSeenBy;
     private final Entity tracker;
 
     public CitizensEntityTracker(ChunkMap map, Entity entity, int i, int j, boolean flag) {
         map.super(entity, i, j, flag);
+        this.rawSeenBy = seenBy;
         this.tracker = entity;
         try {
-            Set<ServerPlayerConnection> set = seenBy;
             TRACKING_SET_SETTER.invoke(this, new ForwardingSet<ServerPlayerConnection>() {
                 @Override
                 public boolean add(ServerPlayerConnection conn) {
@@ -45,7 +50,7 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
 
                 @Override
                 protected Set<ServerPlayerConnection> delegate() {
-                    return set;
+                    return rawSeenBy;
                 }
 
                 @Override
@@ -70,29 +75,63 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
     private void cancellableUpdatePlayer(final NPC npc, final ServerPlayer entityplayer,
             final java.util.function.Consumer<Boolean> callback) {
         CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(), () -> {
-            NPCSeenByPlayerEvent event = new NPCSeenByPlayerEvent(npc, entityplayer.getBukkitEntity());
-            try {
-                Bukkit.getPluginManager().callEvent(event);
-            } catch (IllegalStateException e) {
-                REQUIRES_SYNC = true;
-                throw e;
-            }
-            if (event.isCancelled()) {
-                callback.accept(true);
-                return;
-            }
-            Integer trackingRange = npc.data().get(NPC.Metadata.TRACKING_RANGE);
-            if (TRACKING_RANGE_SETTER != null && trackingRange != null
-                    && npc.data().get("last-tracking-range", -1) != trackingRange.intValue()) {
-                try {
-                    TRACKING_RANGE_SETTER.invoke(CitizensEntityTracker.this, trackingRange);
-                    npc.data().set("last-tracking-range", trackingRange);
-                } catch (Throwable e) {
-                    e.printStackTrace();
-                }
-            }
-            callback.accept(false);
+            callback.accept(isUpdateCancelled(npc, entityplayer));
         });
+    }
+
+    private boolean isUpdateCancelled(final NPC npc, final ServerPlayer entityplayer) {
+        NPCSeenByPlayerEvent event = new NPCSeenByPlayerEvent(npc, entityplayer.getBukkitEntity());
+        try {
+            Bukkit.getPluginManager().callEvent(event);
+        } catch (IllegalStateException e) {
+            REQUIRES_SYNC = true;
+            throw e;
+        }
+        if (event.isCancelled()) {
+            return true;
+        }
+        Integer trackingRange = npc.data().get(NPC.Metadata.TRACKING_RANGE);
+        if (TRACKING_RANGE_SETTER != null && trackingRange != null
+                && npc.data().get("last-tracking-range", -1) != trackingRange.intValue()) {
+            try {
+                TRACKING_RANGE_SETTER.invoke(CitizensEntityTracker.this, trackingRange);
+                npc.data().set("last-tracking-range", trackingRange);
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+        }
+        return false;
+    }
+
+    private void updatePlayerFolia(final ServerPlayer entityplayer) {
+        UUID playerId = entityplayer.getUUID();
+        if (!foliaPendingUpdates.add(playerId)) {
+            return;
+        }
+        CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(), () -> {
+            try {
+                if (tracker.isRemoved()) {
+                    return;
+                }
+                if (!seenBy.contains(entityplayer.connection) && tracker instanceof NPCHolder
+                        && isUpdateCancelled(((NPCHolder) tracker).getNPC(), entityplayer)) {
+                    return;
+                }
+                super.updatePlayer(entityplayer);
+            } finally {
+                foliaPendingUpdates.remove(playerId);
+            }
+        });
+    }
+
+    @Override
+    public void removePlayer(final ServerPlayer entityplayer) {
+        if (!SpigotUtil.isFoliaServer()) {
+            super.removePlayer(entityplayer);
+            return;
+        }
+        CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(),
+                () -> CitizensEntityTracker.super.removePlayer(entityplayer));
     }
 
     @Override
@@ -100,6 +139,10 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
         if (entityplayer instanceof EntityHumanNPC)
             return;
 
+        if (SpigotUtil.isFoliaServer()) {
+            updatePlayerFolia(entityplayer);
+            return;
+        }
         if (!tracker.isRemoved() && !seenBy.contains(entityplayer.connection) && tracker instanceof NPCHolder) {
             NPC npc = ((NPCHolder) tracker).getNPC();
             if (REQUIRES_SYNC == null) {
@@ -118,6 +161,10 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
 
     public static Collection<org.bukkit.entity.Entity> getSeenBy(TrackedEntity tracker) {
         return tracker.seenBy.stream().map(c -> c.getPlayer().getBukkitEntity()).collect(Collectors.toSet());
+    }
+
+    static void transferSeenBy(TrackedEntity previous, CitizensEntityTracker replacement) {
+        replacement.rawSeenBy.addAll(previous.seenBy);
     }
 
     private static boolean getTrackDelta(TrackedEntity entry) {

--- a/v26_1_R1/src/main/java/net/citizensnpcs/nms/v26_1_R1/util/NMSImpl.java
+++ b/v26_1_R1/src/main/java/net/citizensnpcs/nms/v26_1_R1/util/NMSImpl.java
@@ -1437,8 +1437,8 @@ public class NMSImpl implements NMSBridge {
                 entry = getTrackedEntityFolia(handle);
                 if (entry == null)
                     return;
-                entry.broadcastRemoved();
                 CitizensEntityTracker newTracker = new CitizensEntityTracker(server.getChunkSource().chunkMap, entry);
+                CitizensEntityTracker.transferSeenBy(entry, newTracker);
                 try {
                     ENTITY_TRACKER_SETTER_FOLIA.invoke(handle, newTracker);
                 } catch (Throwable t) {

--- a/v26_2_R1/src/main/java/net/citizensnpcs/nms/v26_2_R1/util/CitizensEntityTracker.java
+++ b/v26_2_R1/src/main/java/net/citizensnpcs/nms/v26_2_R1/util/CitizensEntityTracker.java
@@ -3,6 +3,8 @@ package net.citizensnpcs.nms.v26_2_R1.util;
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
@@ -14,6 +16,7 @@ import net.citizensnpcs.api.event.NPCLinkToPlayerEvent;
 import net.citizensnpcs.api.event.NPCSeenByPlayerEvent;
 import net.citizensnpcs.api.event.NPCUnlinkFromPlayerEvent;
 import net.citizensnpcs.api.npc.NPC;
+import net.citizensnpcs.api.util.SpigotUtil;
 import net.citizensnpcs.nms.v26_2_R1.entity.EntityHumanNPC;
 import net.citizensnpcs.npc.ai.NPCHolder;
 import net.citizensnpcs.util.NMS;
@@ -25,13 +28,15 @@ import net.minecraft.server.network.ServerPlayerConnection;
 import net.minecraft.world.entity.Entity;
 
 public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
+    private final Set<UUID> foliaPendingUpdates = ConcurrentHashMap.newKeySet();
+    private final Set<ServerPlayerConnection> rawSeenBy;
     private final Entity tracker;
 
     public CitizensEntityTracker(ChunkMap map, Entity entity, int i, int j, boolean flag) {
         map.super(entity, i, j, flag);
+        this.rawSeenBy = seenBy;
         this.tracker = entity;
         try {
-            Set<ServerPlayerConnection> set = seenBy;
             TRACKING_SET_SETTER.invoke(this, new ForwardingSet<ServerPlayerConnection>() {
                 @Override
                 public boolean add(ServerPlayerConnection conn) {
@@ -45,7 +50,7 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
 
                 @Override
                 protected Set<ServerPlayerConnection> delegate() {
-                    return set;
+                    return rawSeenBy;
                 }
 
                 @Override
@@ -70,29 +75,63 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
     private void cancellableUpdatePlayer(final NPC npc, final ServerPlayer entityplayer,
             final java.util.function.Consumer<Boolean> callback) {
         CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(), () -> {
-            NPCSeenByPlayerEvent event = new NPCSeenByPlayerEvent(npc, entityplayer.getBukkitEntity());
-            try {
-                Bukkit.getPluginManager().callEvent(event);
-            } catch (IllegalStateException e) {
-                REQUIRES_SYNC = true;
-                throw e;
-            }
-            if (event.isCancelled()) {
-                callback.accept(true);
-                return;
-            }
-            Integer trackingRange = npc.data().get(NPC.Metadata.TRACKING_RANGE);
-            if (TRACKING_RANGE_SETTER != null && trackingRange != null
-                    && npc.data().get("last-tracking-range", -1) != trackingRange.intValue()) {
-                try {
-                    TRACKING_RANGE_SETTER.invoke(CitizensEntityTracker.this, trackingRange);
-                    npc.data().set("last-tracking-range", trackingRange);
-                } catch (Throwable e) {
-                    e.printStackTrace();
-                }
-            }
-            callback.accept(false);
+            callback.accept(isUpdateCancelled(npc, entityplayer));
         });
+    }
+
+    private boolean isUpdateCancelled(final NPC npc, final ServerPlayer entityplayer) {
+        NPCSeenByPlayerEvent event = new NPCSeenByPlayerEvent(npc, entityplayer.getBukkitEntity());
+        try {
+            Bukkit.getPluginManager().callEvent(event);
+        } catch (IllegalStateException e) {
+            REQUIRES_SYNC = true;
+            throw e;
+        }
+        if (event.isCancelled()) {
+            return true;
+        }
+        Integer trackingRange = npc.data().get(NPC.Metadata.TRACKING_RANGE);
+        if (TRACKING_RANGE_SETTER != null && trackingRange != null
+                && npc.data().get("last-tracking-range", -1) != trackingRange.intValue()) {
+            try {
+                TRACKING_RANGE_SETTER.invoke(CitizensEntityTracker.this, trackingRange);
+                npc.data().set("last-tracking-range", trackingRange);
+            } catch (Throwable e) {
+                e.printStackTrace();
+            }
+        }
+        return false;
+    }
+
+    private void updatePlayerFolia(final ServerPlayer entityplayer) {
+        UUID playerId = entityplayer.getUUID();
+        if (!foliaPendingUpdates.add(playerId)) {
+            return;
+        }
+        CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(), () -> {
+            try {
+                if (tracker.isRemoved()) {
+                    return;
+                }
+                if (!seenBy.contains(entityplayer.connection) && tracker instanceof NPCHolder
+                        && isUpdateCancelled(((NPCHolder) tracker).getNPC(), entityplayer)) {
+                    return;
+                }
+                super.updatePlayer(entityplayer);
+            } finally {
+                foliaPendingUpdates.remove(playerId);
+            }
+        });
+    }
+
+    @Override
+    public void removePlayer(final ServerPlayer entityplayer) {
+        if (!SpigotUtil.isFoliaServer()) {
+            super.removePlayer(entityplayer);
+            return;
+        }
+        CitizensAPI.getScheduler().checkedRunEntityTask(entityplayer.getBukkitEntity(),
+                () -> CitizensEntityTracker.super.removePlayer(entityplayer));
     }
 
     @Override
@@ -100,6 +139,10 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
         if (entityplayer instanceof EntityHumanNPC)
             return;
 
+        if (SpigotUtil.isFoliaServer()) {
+            updatePlayerFolia(entityplayer);
+            return;
+        }
         if (!tracker.isRemoved() && !seenBy.contains(entityplayer.connection) && tracker instanceof NPCHolder) {
             NPC npc = ((NPCHolder) tracker).getNPC();
             if (REQUIRES_SYNC == null) {
@@ -118,6 +161,10 @@ public class CitizensEntityTracker extends ChunkMap.TrackedEntity {
 
     public static Collection<org.bukkit.entity.Entity> getSeenBy(TrackedEntity tracker) {
         return tracker.seenBy.stream().map(c -> c.getPlayer().getBukkitEntity()).collect(Collectors.toSet());
+    }
+
+    static void transferSeenBy(TrackedEntity previous, CitizensEntityTracker replacement) {
+        replacement.rawSeenBy.addAll(previous.seenBy);
     }
 
     private static boolean getTrackDelta(TrackedEntity entry) {

--- a/v26_2_R1/src/main/java/net/citizensnpcs/nms/v26_2_R1/util/NMSImpl.java
+++ b/v26_2_R1/src/main/java/net/citizensnpcs/nms/v26_2_R1/util/NMSImpl.java
@@ -1440,8 +1440,8 @@ public class NMSImpl implements NMSBridge {
                 entry = getTrackedEntityFolia(handle);
                 if (entry == null)
                     return;
-                entry.broadcastRemoved();
                 CitizensEntityTracker newTracker = new CitizensEntityTracker(server.getChunkSource().chunkMap, entry);
+                CitizensEntityTracker.transferSeenBy(entry, newTracker);
                 try {
                     ENTITY_TRACKER_SETTER_FOLIA.invoke(handle, newTracker);
                 } catch (Throwable t) {


### PR DESCRIPTION
## Summary

- Run Folia tracker add/update and remove operations on the viewer's entity
  scheduler.
- Deduplicate pending viewer updates by UUID.
- Preserve the existing raw `seenBy` connections when replacing a Folia
  tracker.
- Avoid broadcasting a removal packet during Folia-only tracker replacement.
- Apply the change consistently to `v1_21_R7`, `v26_1_R1`, and `v26_2_R1`.

## Problem

The Folia tracker replacement path called `broadcastRemoved()` before replacing
the vanilla tracker. That removes the NPC from every current viewer, while the
new tracker starts with an empty `seenBy` set and relies on a later asynchronous
tracking update to link the entity again. Under repeated NPC death, respawn,
and tracker replacement, a client could remain permanently desynchronized:
other NPCs continued interacting with the entity, but the player received no
entity, equipment, or hitbox.

Additionally, only the event-gated new-link path was sent through the viewer's
entity scheduler. Existing-link updates and removals could still call the
vanilla tracker directly from another Folia region.

This patch retains the current viewers without sending a removal packet and
serializes all Folia viewer tracker mutations through the viewer entity
scheduler. Existing Paper behavior is unchanged.

## Testing

- Rebased onto current Citizens `master`.
- Full Maven `compile` reactor passes for `v1_21_R7`, `v26_1_R1`, and
  `v26_2_R1`.
- The equivalent `v26_1_R1` behavior was exercised with a Citizens
  b4220-derived build on Folia 26.1.2 and Canvas 26.1.2 using 100 Crystal combat
  NPCs with repeated explosions, deaths, and respawns. The invisible,
  non-interactable NPC state did not recur after the final tracker fix.

The implementation uses the generic Citizens Folia scheduler abstraction and
contains no Canvas-specific code.